### PR TITLE
Bot management overhaul

### DIFF
--- a/parachute/api/health.py
+++ b/parachute/api/health.py
@@ -86,6 +86,16 @@ async def health_check(
     if docker_available:
         docker_info["image_exists"] = await sandbox.image_exists()
 
+    # Bot connector status
+    from parachute.api.bots import _connectors
+    bots = {}
+    for platform in ("telegram", "discord"):
+        connector = _connectors.get(platform)
+        if connector:
+            bots[platform] = {"running": connector._running}
+        else:
+            bots[platform] = {"running": False}
+
     return {
         **basic,
         "vault": {
@@ -94,5 +104,6 @@ async def health_check(
         },
         "modules": modules_status,
         "docker": docker_info,
+        "bots": bots,
         "uptime": time.time() - _start_time,
     }

--- a/parachute/connectors/discord_bot.py
+++ b/parachute/connectors/discord_bot.py
@@ -132,18 +132,20 @@ class DiscordConnector(BotConnector):
         message = update  # In Discord, 'update' is a discord.Message
 
         user_id = str(message.author.id)
+        chat_type = "dm" if isinstance(message.channel, discord.DMChannel) else "group"
         if not self.is_user_allowed(user_id):
             response = await self.handle_unknown_user(
                 platform="discord",
                 user_id=user_id,
                 user_display=message.author.display_name,
                 chat_id=str(message.channel.id),
+                chat_type=chat_type,
+                message_text=message.content,
             )
             await message.reply(response)
             return
 
         chat_id = str(message.channel.id)
-        chat_type = "dm" if isinstance(message.channel, discord.DMChannel) else "group"
         message_text = message.content
 
         # Group mention gating: only respond to @mentions in guild channels
@@ -161,6 +163,7 @@ class DiscordConnector(BotConnector):
             chat_id=chat_id,
             chat_type=chat_type,
             user_display=message.author.display_name,
+            user_id=str(message.author.id),
         )
 
         if not session:
@@ -211,11 +214,14 @@ class DiscordConnector(BotConnector):
         """Handle /chat slash command."""
         user_id = str(interaction.user.id)
         if not self.is_user_allowed(user_id):
+            chat_type = "dm" if interaction.guild is None else "group"
             response = await self.handle_unknown_user(
                 platform="discord",
                 user_id=user_id,
                 user_display=interaction.user.display_name,
                 chat_id=str(interaction.channel_id),
+                chat_type=chat_type,
+                message_text=message,
             )
             await interaction.response.send_message(response, ephemeral=True)
             return
@@ -230,6 +236,7 @@ class DiscordConnector(BotConnector):
             chat_id=chat_id,
             chat_type=chat_type,
             user_display=interaction.user.display_name,
+            user_id=str(interaction.user.id),
         )
 
         if not session:
@@ -255,11 +262,13 @@ class DiscordConnector(BotConnector):
         """Handle /journal slash command."""
         user_id = str(interaction.user.id)
         if not self.is_user_allowed(user_id):
+            chat_type = "dm" if interaction.guild is None else "group"
             response = await self.handle_unknown_user(
                 platform="discord",
                 user_id=user_id,
                 user_display=interaction.user.display_name,
                 chat_id=str(interaction.channel_id),
+                chat_type=chat_type,
             )
             await interaction.response.send_message(response, ephemeral=True)
             return

--- a/parachute/connectors/telegram.py
+++ b/parachute/connectors/telegram.py
@@ -118,11 +118,13 @@ class TelegramConnector(BotConnector):
         """Handle /start command."""
         user_id = update.effective_user.id
         if not self.is_user_allowed(user_id):
+            chat_type = "dm" if update.effective_chat.type == "private" else "group"
             response = await self.handle_unknown_user(
                 platform="telegram",
                 user_id=str(user_id),
                 user_display=update.effective_user.full_name,
                 chat_id=str(update.effective_chat.id),
+                chat_type=chat_type,
             )
             await update.message.reply_text(response)
             return
@@ -166,11 +168,13 @@ class TelegramConnector(BotConnector):
         """Handle /journal command - route to Daily module."""
         user_id = update.effective_user.id
         if not self.is_user_allowed(user_id):
+            chat_type = "dm" if update.effective_chat.type == "private" else "group"
             response = await self.handle_unknown_user(
                 platform="telegram",
                 user_id=str(user_id),
                 user_display=update.effective_user.full_name,
                 chat_id=str(update.effective_chat.id),
+                chat_type=chat_type,
             )
             await update.message.reply_text(response)
             return
@@ -192,11 +196,14 @@ class TelegramConnector(BotConnector):
         """Handle incoming text message."""
         user_id = update.effective_user.id
         if not self.is_user_allowed(user_id):
+            chat_type = "dm" if update.effective_chat.type == "private" else "group"
             response = await self.handle_unknown_user(
                 platform="telegram",
                 user_id=str(user_id),
                 user_display=update.effective_user.full_name,
                 chat_id=str(update.effective_chat.id),
+                chat_type=chat_type,
+                message_text=update.message.text,
             )
             await update.message.reply_text(response)
             return
@@ -223,6 +230,7 @@ class TelegramConnector(BotConnector):
             chat_id=chat_id,
             chat_type=chat_type,
             user_display=update.effective_user.full_name,
+            user_id=str(update.effective_user.id),
         )
 
         if not session:
@@ -256,11 +264,13 @@ class TelegramConnector(BotConnector):
         """Handle incoming voice message."""
         user_id = update.effective_user.id
         if not self.is_user_allowed(user_id):
+            chat_type = "dm" if update.effective_chat.type == "private" else "group"
             response = await self.handle_unknown_user(
                 platform="telegram",
                 user_id=str(user_id),
                 user_display=update.effective_user.full_name,
                 chat_id=str(update.effective_chat.id),
+                chat_type=chat_type,
             )
             await update.message.reply_text(response)
             return

--- a/parachute/server.py
+++ b/parachute/server.py
@@ -111,7 +111,7 @@ async def lifespan(app: FastAPI):
         app.state.hook_runner = None
 
     # Initialize bots API (pass server_ref with database for connector sessions)
-    from parachute.api.bots import init_bots_api
+    from parachute.api.bots import init_bots_api, auto_start_connectors
     from types import SimpleNamespace
 
     async def orchestrate(session_id, message, source="bot"):
@@ -136,6 +136,9 @@ async def lifespan(app: FastAPI):
         orchestrate=orchestrate,
     )
     init_bots_api(vault_path=settings.vault_path, server_ref=server_ref)
+
+    # Auto-start enabled bot connectors (errors logged, never crash server)
+    await auto_start_connectors()
 
     logger.info("Server ready")
 


### PR DESCRIPTION
## Summary
Remaining commits from stacked PR #2 (bot management), which was merged into `feat/cli-daemon-management`.

- **Fix 422 bug**: Split `PlatformConfigUpdate` into platform-specific types
- **Auto-start bots**: Enabled connectors start automatically on server startup
- **Pending sessions**: Unknown users get pending sessions visible in Chat list
- **CLI bot commands**: `parachute bot status/start/stop/config/approve/deny/users`
- **Config write lock**: Serialized bots.yaml writes with connector restart on save
- **Per-user trust override**: Custom trust levels via pairing approvals
- **Health endpoint**: Bot connector state in detailed health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)