### PR TITLE
refactor(paths): unify working directories to /vault/...

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,17 @@ exec "$REPO_DIR/.venv/bin/python" -m parachute "\$@"
 SCRIPT
 chmod +x "$WRAPPER"
 
+# --- Create /vault symlink for path unification ---
+# Both bare metal and Docker sessions use /vault/... paths.
+# The interactive `parachute install` flow also creates this.
+
+if [ ! -e /vault ]; then
+    echo ""
+    echo "Parachute uses /vault as a unified path for all sessions."
+    echo "This requires a symlink: /vault → your vault directory."
+    echo "(The interactive setup will prompt for your vault path.)"
+fi
+
 # --- Check PATH ---
 
 if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then

--- a/parachute/core/orchestrator.py
+++ b/parachute/core/orchestrator.py
@@ -302,8 +302,8 @@ class Orchestrator:
         config_overrides = (session.metadata or {}).get("config_overrides", {}) if hasattr(session, "metadata") else {}
 
         # Determine working directory first (needed for prompt building)
-        # Priority: explicit param > config_overrides > session's stored value > vault path
-        # Note: working_directory is stored as RELATIVE to vault_path in the database
+        # Priority: explicit param > config_overrides > session's stored value > /vault
+        # Note: working_directory is stored as /vault/... absolute paths in the database
         override_working_dir = config_overrides.get("working_directory")
         effective_working_dir: Optional[str] = working_directory or override_working_dir or session.working_directory
         effective_cwd = self.session_manager.resolve_working_directory(effective_working_dir)
@@ -324,16 +324,16 @@ class Orchestrator:
                 else:
                     logger.warning(
                         f"Working directory does not exist: {effective_cwd}, "
-                        f"falling back to vault path: {self.vault_path}"
+                        f"falling back to /vault"
                     )
-                    effective_cwd = self.vault_path
+                    effective_cwd = Path("/vault")
                     effective_working_dir = None
             else:
                 logger.warning(
                     f"Working directory does not exist: {effective_cwd}, "
-                    f"falling back to vault path: {self.vault_path}"
+                    f"falling back to /vault"
                 )
-                effective_cwd = self.vault_path
+                effective_cwd = Path("/vault")
                 effective_working_dir = None
 
         # Apply system prompt override from config_overrides (only if no explicit prompt given)


### PR DESCRIPTION
## Summary
- `resolve_working_directory()` now returns `/vault` instead of the real host path, so bare metal and Docker sessions use identical `/vault/...` paths
- Legacy absolute host paths (e.g., `/Volumes/ExternalSSD/Parachute/Projects/foo`) are automatically converted to `/vault/Projects/foo`
- Path traversal validation works without requiring `/vault` symlink to exist on disk
- `get_sdk_transcript_path` uses `/vault` paths — `resolve()` follows the symlink, so encoded transcript paths stay backward-compatible
- Orchestrator CWD fallbacks use `/vault` instead of `self.vault_path`
- `install.sh` informs users about the `/vault` symlink (actual creation is handled by `parachute install` CLI)

## Context
This completes the path unification phase of the trust model simplification. The `/vault` symlink (created by `parachute install`) provides a consistent filesystem view across bare metal and Docker execution contexts. DB migration v15 (already in main) converts legacy relative paths to `/vault/...` format.

## Test plan
- [x] `resolve_working_directory(None)` → `Path("/vault")`
- [x] `resolve_working_directory("/vault/Projects/foo")` → as-is
- [x] `resolve_working_directory("Projects/foo")` → `/vault/Projects/foo`
- [x] `resolve_working_directory("/Volumes/.../Projects/foo")` → `/vault/Projects/foo`
- [x] Path traversal (`/vault/../../etc/passwd`) → blocked, returns `/vault`
- [x] `normalize_working_directory` round-trips correctly
- [x] All imports successful
- [ ] Manual: `sudo ln -sf ~/Parachute /vault` then verify server starts and sessions get `/vault` CWD