### PR TITLE
cleanup: remove /vault symlink from install flow

### DIFF
--- a/parachute/core/session_manager.py
+++ b/parachute/core/session_manager.py
@@ -33,8 +33,9 @@ class SessionManager:
     - SDK session ID is the ONLY identifier (no separate Parachute session ID)
     - Messages are stored in SDK JSONL files, not our database
     - We store metadata for indexing and quick listing
-    - working_directory is stored as /vault/... absolute path (consistent for bare metal and Docker)
-    - Empty/null working_directory means /vault (vault root)
+    - working_directory is stored as /vault/... in the DB (normalized for portability)
+    - SDK CWD uses the real vault host path (resolve_working_directory)
+    - Empty/null working_directory means vault root
     """
 
     def __init__(self, vault_path: Path, database: Database):


### PR DESCRIPTION
## Summary
- Removes `_create_vault_symlink()` function from CLI (~45 lines)
- Removes the call to it during `parachute install`
- Updates session_manager docstring to reflect that SDK CWD uses the real host path

## Why
macOS root filesystem is read-only since Catalina. Creating `/vault` requires `/etc/synthetic.conf` + reboot — too invasive for an app. The DB normalization to `/vault/...` paths (via `normalize_working_directory()`) still works without the symlink, providing portable path storage while the SDK uses real host paths at runtime.

## Test plan
- [x] `parachute` CLI imports successfully
- [x] No remaining references to `_create_vault_symlink`