### PR TITLE
refactor(trust): workspace trust is default, not floor

### DIFF
--- a/parachute/core/orchestrator.py
+++ b/parachute/core/orchestrator.py
@@ -27,7 +27,7 @@ from parachute.db.database import Database
 from parachute.lib.agent_loader import build_system_prompt, load_agent
 from parachute.lib.context_loader import format_context_for_prompt, load_agent_context
 from parachute.core.context_folders import ContextFolderService
-from parachute.core.capability_filter import filter_by_trust_level, filter_capabilities, trust_rank
+from parachute.core.capability_filter import filter_by_trust_level, filter_capabilities
 from parachute.lib.mcp_loader import load_mcp_servers, resolve_mcp_servers, validate_and_filter_servers
 from parachute.models.agent import AgentDefinition, AgentType, create_vault_agent
 from parachute.models.events import (
@@ -536,35 +536,34 @@ class Orchestrator:
                 logger.info(f"Loaded {len(agents_dict)} custom agents")
 
             # Determine effective trust level early (needed for capability filtering)
-            # Trust level routing: session → workspace floor → client override
-            session_trust = session.get_trust_level()
-
-            if workspace_config and workspace_config.trust_level:
-                try:
-                    # Map legacy workspace trust values
-                    _legacy = {"full": "trusted", "vault": "trusted", "sandboxed": "untrusted"}
-                    ws_trust_str = _legacy.get(workspace_config.trust_level, workspace_config.trust_level)
-                    workspace_trust = TrustLevel(ws_trust_str)
-                    if trust_rank(workspace_trust) > trust_rank(session_trust):
-                        logger.info(f"Workspace trust floor restricts session from {session_trust.value} to {workspace_trust.value}")
-                        session_trust = workspace_trust
-                except ValueError:
-                    logger.warning(f"Invalid workspace trust_level: {workspace_config.trust_level}")
+            # Priority: client param > session stored > workspace default > trusted
+            _legacy = {"full": "trusted", "vault": "trusted", "sandboxed": "untrusted"}
 
             if trust_level:
+                # Client explicitly set trust level — use it
                 try:
-                    # Map legacy client trust values
-                    _legacy = {"full": "trusted", "vault": "trusted", "sandboxed": "untrusted"}
-                    client_trust_str = _legacy.get(trust_level, trust_level)
-                    requested = TrustLevel(client_trust_str)
-                    if trust_rank(requested) >= trust_rank(session_trust):
-                        session_trust = requested
-                    else:
-                        logger.warning(
-                            f"Client tried to escalate trust from {session_trust.value} to {requested.value}, ignoring"
-                        )
+                    mapped = _legacy.get(trust_level, trust_level)
+                    session_trust = TrustLevel(mapped)
                 except ValueError:
                     logger.warning(f"Invalid trust_level from client: {trust_level}")
+                    session_trust = session.get_trust_level()
+            elif session.trust_level:
+                # Session has stored trust level (resumed session)
+                session_trust = session.get_trust_level()
+            elif workspace_config and workspace_config.default_trust_level:
+                # Workspace provides default
+                try:
+                    ws_trust_str = _legacy.get(
+                        workspace_config.default_trust_level,
+                        workspace_config.default_trust_level,
+                    )
+                    session_trust = TrustLevel(ws_trust_str)
+                    logger.info(f"Using workspace default trust: {session_trust.value}")
+                except ValueError:
+                    logger.warning(f"Invalid workspace default_trust_level: {workspace_config.default_trust_level}")
+                    session_trust = TrustLevel.TRUSTED
+            else:
+                session_trust = TrustLevel.TRUSTED
 
             effective_trust = session_trust.value
 

--- a/parachute/core/workspaces.py
+++ b/parachute/core/workspaces.py
@@ -116,7 +116,7 @@ def create_workspace(vault_path: Path, create: WorkspaceCreate) -> WorkspaceConf
         name=create.name,
         slug=slug,
         description=create.description,
-        trust_level=create.trust_level,
+        default_trust_level=create.default_trust_level,
         working_directory=create.working_directory,
         model=create.model,
         capabilities=create.capabilities or WorkspaceCapabilities(),
@@ -173,6 +173,9 @@ def _load_workspace(slug: str, config_file: Path) -> WorkspaceConfig:
         data = yaml.safe_load(f) or {}
 
     data["slug"] = slug
+    # Migrate old field name: trust_level -> default_trust_level
+    if "trust_level" in data and "default_trust_level" not in data:
+        data["default_trust_level"] = data.pop("trust_level")
     return WorkspaceConfig(**data)
 
 

--- a/parachute/models/workspace.py
+++ b/parachute/models/workspace.py
@@ -70,9 +70,9 @@ class WorkspaceConfig(BaseModel):
     name: str = Field(description="Display name")
     slug: str = Field(description="URL-safe identifier (kebab-case)")
     description: str = Field(default="", description="Description")
-    trust_level: TrustLevelStr = Field(
+    default_trust_level: TrustLevelStr = Field(
         default="trusted",
-        description="Trust floor: trusted (bare metal) or untrusted (Docker)",
+        description="Default trust level for new sessions in this workspace",
     )
     working_directory: Optional[str] = Field(
         default=None,
@@ -107,7 +107,7 @@ class WorkspaceCreate(BaseModel):
 
     name: str = Field(description="Display name")
     description: str = Field(default="", description="Description")
-    trust_level: TrustLevelStr = Field(default="trusted", description="Trust floor")
+    default_trust_level: TrustLevelStr = Field(default="trusted", description="Default trust level")
     working_directory: Optional[str] = Field(default=None)
     model: Optional[str] = Field(default=None)
     capabilities: Optional[WorkspaceCapabilities] = Field(default=None)
@@ -119,7 +119,7 @@ class WorkspaceUpdate(BaseModel):
 
     name: Optional[str] = Field(default=None)
     description: Optional[str] = Field(default=None)
-    trust_level: Optional[TrustLevelStr] = Field(default=None, description="Trust floor")
+    default_trust_level: Optional[TrustLevelStr] = Field(default=None, description="Default trust level")
     working_directory: Optional[str] = Field(default=None)
     model: Optional[str] = Field(default=None)
     capabilities: Optional[WorkspaceCapabilities] = Field(default=None)


### PR DESCRIPTION
## Summary
- Rename `trust_level` to `default_trust_level` in `WorkspaceConfig`, `WorkspaceCreate`, and `WorkspaceUpdate` models
- Simplify orchestrator trust resolution from three-step floor enforcement to priority-based: client param > session stored > workspace default > trusted
- Sessions can now freely override workspace trust in either direction (no escalation prevention)
- Remove `trust_rank()` import from orchestrator (no longer needed)
- YAML migration: `_load_workspace()` reads either `default_trust_level` or `trust_level` for backward compatibility

## Test plan
- [ ] Create workspace with `default_trust_level: untrusted` — new sessions default to untrusted
- [ ] Override trust to `trusted` on a session in an `untrusted` workspace — should work (no floor)
- [ ] Existing YAML configs with `trust_level:` key load correctly via migration
- [ ] API response returns `default_trust_level` key (not `trust_level`)
- [ ] Server starts cleanly with `parachute server -f`

**Deploy note**: This is a breaking API change — workspace responses use `default_trust_level` instead of `trust_level`. The Flutter client (companion PR) handles both keys for backward compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)