### PR TITLE
feat: agent CRUD, sandbox fixes, Docker CLI messaging

### DIFF
--- a/parachute/__init__.py
+++ b/parachute/__init__.py
@@ -4,4 +4,4 @@ Parachute Base Server
 Backend server for the Parachute ecosystem - AI agents, session management, and vault operations.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/parachute/api/chat.py
+++ b/parachute/api/chat.py
@@ -52,7 +52,8 @@ async def event_generator(request: Request, chat_request: ChatRequest):
 
     logger.info(
         f"Chat request: session={chat_request.session_id or 'new'} "
-        f"module={chat_request.module} contexts={chat_request.contexts}"
+        f"module={chat_request.module} trust={chat_request.trust_level} "
+        f"workspace={chat_request.workspace_id} contexts={chat_request.contexts}"
     )
 
     # Normalize 'new' to None - client sends 'new' when it wants a new session

--- a/parachute/server.py
+++ b/parachute/server.py
@@ -24,6 +24,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
+from parachute import __version__
 from parachute.api import api_router
 from parachute.config import get_settings, Settings
 from parachute.core.module_loader import ModuleLoader
@@ -185,7 +186,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Parachute Computer",
     description="Modular backend server for Parachute ecosystem - AI agents, session management, and vault operations",
-    version="0.1.0",
+    version=__version__,
     lifespan=lifespan,
 )
 
@@ -301,7 +302,7 @@ async def root():
     """Root endpoint - returns server info."""
     return {
         "name": "Parachute Computer",
-        "version": "0.1.0",
+        "version": __version__,
         "status": "running",
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parachute-computer"
-version = "0.1.0"
+version = "0.2.0"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.109.0",


### PR DESCRIPTION
## Summary
- **Agent CRUD endpoints**: POST /api/agents, POST /api/agents/upload, DELETE /api/agents/{name} for managing custom agents from the UI
- **Sandbox CWD fix**: Prefix relative working directory paths with `/vault/` so containers find the mounted workspace
- **Sandbox model fix**: Pass configured model through `PARACHUTE_MODEL` env var to entrypoint so untrusted sessions use the correct model
- **Sandbox hardening**: Pre-check image exists, probe SDK for `plugin_dirs` support before passing
- **Docker CLI messaging**: Platform-specific install instructions in `parachute install` and `parachute doctor`
- **Logging**: Trust level and workspace info in chat request handler

## Test plan
- [ ] `curl -X POST localhost:3333/api/agents -H 'Content-Type: application/json' -d '{"name":"test","description":"test","prompt":"You are a test."}'` returns 200
- [ ] `curl -X DELETE localhost:3333/api/agents/test` returns 200
- [ ] Start untrusted workspace session — verify CWD shows `/vault/Workspaces/...` not `/workspace`
- [ ] Untrusted session uses configured model (opus) not SDK default (sonnet)
- [ ] `parachute install` with Docker not installed shows platform-specific install instructions
- [ ] `parachute doctor` Docker checks show actionable hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)