### PR TITLE
fix: Discover Claude Code CLI-installed plugins

### DIFF
--- a/parachute/core/plugins.py
+++ b/parachute/core/plugins.py
@@ -3,7 +3,8 @@ Plugin discovery and indexing.
 
 Discovers installed plugins from:
 1. {vault}/.parachute/plugins/  — Parachute-managed plugins (installed via API)
-2. ~/.claude/plugins/           — User plugins (shared with Claude Code CLI)
+2. ~/.claude/plugins/installed_plugins.json — Claude Code CLI installed plugins
+3. ~/.claude/plugins/ top-level dirs — Legacy user plugins (direct placement)
 
 Each plugin must have .claude-plugin/plugin.json to be recognized.
 Plugin contents (skills, agents, MCPs) are indexed for capability filtering.
@@ -11,7 +12,6 @@ Plugin contents (skills, agents, MCPs) are indexed for capability filtering.
 
 import json
 import logging
-import re
 from pathlib import Path
 from typing import Optional
 
@@ -34,6 +34,7 @@ def discover_plugins(
         List of discovered and indexed plugins
     """
     plugins: list[InstalledPlugin] = []
+    seen_paths: set[str] = set()  # Deduplicate by path
 
     # 1. Parachute-managed plugins
     plugin_dir = vault_path / ".parachute" / "plugins"
@@ -43,19 +44,81 @@ def discover_plugins(
                 plugin = _index_plugin(entry, source="parachute")
                 if plugin:
                     plugins.append(plugin)
+                    seen_paths.add(str(entry.resolve()))
 
-    # 2. User plugins (~/.claude/plugins/)
+    # 2. Claude Code CLI installed plugins (from installed_plugins.json)
     if include_user:
+        cli_plugins = _discover_cli_plugins()
+        for plugin in cli_plugins:
+            resolved = str(Path(plugin.path).resolve())
+            if resolved not in seen_paths:
+                plugins.append(plugin)
+                seen_paths.add(resolved)
+
+        # 3. Legacy: top-level dirs in ~/.claude/plugins/ with plugin.json
         user_dir = Path.home() / ".claude" / "plugins"
         if user_dir.is_dir():
             for entry in sorted(user_dir.iterdir()):
-                if entry.is_dir() and (entry / ".claude-plugin" / "plugin.json").exists():
-                    plugin = _index_plugin(entry, source="user")
-                    if plugin:
-                        plugins.append(plugin)
+                if (
+                    entry.is_dir()
+                    and entry.name not in ("cache", "marketplaces")
+                    and (entry / ".claude-plugin" / "plugin.json").exists()
+                ):
+                    resolved = str(entry.resolve())
+                    if resolved not in seen_paths:
+                        plugin = _index_plugin(entry, source="user")
+                        if plugin:
+                            plugins.append(plugin)
+                            seen_paths.add(resolved)
 
     logger.info(f"Discovered {len(plugins)} plugins")
     return plugins
+
+
+def _discover_cli_plugins() -> list[InstalledPlugin]:
+    """Read ~/.claude/plugins/installed_plugins.json to find CLI-installed plugins."""
+    manifest_path = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+    if not manifest_path.exists():
+        return []
+
+    try:
+        data = json.loads(manifest_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning(f"Failed to read installed_plugins.json: {e}")
+        return []
+
+    version = data.get("version", 1)
+    plugins_map = data.get("plugins", {})
+    results: list[InstalledPlugin] = []
+
+    for plugin_key, installs in plugins_map.items():
+        if not isinstance(installs, list) or not installs:
+            continue
+
+        # Use the first (or most recent) installation entry
+        install = installs[0]
+        install_path = install.get("installPath")
+        if not install_path:
+            continue
+
+        path = Path(install_path)
+        if not path.is_dir():
+            logger.debug(f"CLI plugin path does not exist: {install_path}")
+            continue
+
+        # Extract slug from key: "compound-engineering@every-marketplace" → "compound-engineering"
+        slug = plugin_key.split("@")[0] if "@" in plugin_key else plugin_key
+
+        plugin = _index_plugin(path, source="cli")
+        if plugin:
+            plugin.slug = slug
+            # Override version from installed_plugins.json if available
+            cli_version = install.get("version")
+            if cli_version:
+                plugin.version = cli_version
+            results.append(plugin)
+
+    return results
 
 
 def _index_plugin(path: Path, source: str = "parachute") -> Optional[InstalledPlugin]:
@@ -73,10 +136,10 @@ def _index_plugin(path: Path, source: str = "parachute") -> Optional[InstalledPl
 
     skills = _discover_plugin_skills(path)
     agents = _discover_plugin_agents(path)
-    mcps = _discover_plugin_mcps(path)
+    mcps = _discover_plugin_mcps(path, manifest_data)
 
     # Check for source_url in manifest (set during install)
-    source_url = manifest_data.get("source_url")
+    source_url = manifest_data.get("source_url") or manifest_data.get("repository")
     installed_at = manifest_data.get("installed_at")
 
     return InstalledPlugin(
@@ -84,7 +147,7 @@ def _index_plugin(path: Path, source: str = "parachute") -> Optional[InstalledPl
         name=manifest.name or path.name,
         version=manifest.version,
         description=manifest.description,
-        author=manifest.author,
+        author=manifest.author_name,
         source=source,
         source_url=source_url,
         path=str(path),
@@ -121,28 +184,40 @@ def _discover_plugin_agents(path: Path) -> list[str]:
     if not agents_dir.is_dir():
         return agents
 
-    for entry in agents_dir.iterdir():
-        if entry.is_file() and entry.suffix in (".md", ".yaml", ".yml", ".json"):
-            agents.append(entry.stem)
+    for entry in agents_dir.rglob("*.md"):
+        # Support nested directories: agents/review/code-reviewer.md
+        agents.append(entry.stem)
+    for entry in agents_dir.rglob("*.yaml"):
+        agents.append(entry.stem)
+    for entry in agents_dir.rglob("*.yml"):
+        agents.append(entry.stem)
 
-    return sorted(agents)
+    return sorted(set(agents))
 
 
-def _discover_plugin_mcps(path: Path) -> dict:
-    """Discover MCP server configs inside a plugin."""
+def _discover_plugin_mcps(path: Path, manifest_data: dict = None) -> dict:
+    """Discover MCP server configs inside a plugin.
+
+    Checks both .mcp.json file and mcpServers in plugin.json manifest.
+    """
+    mcps = {}
+
+    # 1. Check .mcp.json file
     mcp_json = path / ".mcp.json"
-    if not mcp_json.exists():
-        return {}
+    if mcp_json.exists():
+        try:
+            data = json.loads(mcp_json.read_text())
+            servers = data.get("mcpServers", {})
+            if isinstance(servers, dict):
+                mcps.update(servers)
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(f"Failed to read plugin MCP config at {mcp_json}: {e}")
 
-    try:
-        data = json.loads(mcp_json.read_text())
-        servers = data.get("mcpServers", {})
-        if isinstance(servers, dict):
-            return servers
-    except (json.JSONDecodeError, OSError) as e:
-        logger.warning(f"Failed to read plugin MCP config at {mcp_json}: {e}")
+    # 2. Check mcpServers in plugin.json manifest
+    if manifest_data and isinstance(manifest_data.get("mcpServers"), dict):
+        mcps.update(manifest_data["mcpServers"])
 
-    return {}
+    return mcps
 
 
 def get_plugin_dirs(plugins: list[InstalledPlugin]) -> list[Path]:

--- a/parachute/models/plugin.py
+++ b/parachute/models/plugin.py
@@ -20,7 +20,16 @@ class PluginManifest(BaseModel):
     name: str = ""
     version: str = "0.0.0"
     description: str = ""
-    author: Optional[str] = None
+    author: Optional[Any] = None  # str or {"name": "...", "email": "..."}
+
+    @property
+    def author_name(self) -> Optional[str]:
+        """Extract author name from string or object."""
+        if isinstance(self.author, str):
+            return self.author
+        if isinstance(self.author, dict):
+            return self.author.get("name")
+        return None
 
 
 class InstalledPlugin(BaseModel):


### PR DESCRIPTION
## Summary

- Read `~/.claude/plugins/installed_plugins.json` to find plugins installed via Claude Code's `/plugin install` command
- These plugins live in `cache/{marketplace}/{plugin}/{version}/` which the old top-level directory scan missed
- Handle `author` as string or object `{"name": "...", "email": "..."}` in plugin.json manifests
- Check `mcpServers` in plugin.json (not just `.mcp.json` file)
- Use `rglob` for nested agent directories (e.g., `agents/review/code-reviewer.md`)
- Deduplicate plugins by resolved path

## Test plan

- [ ] `curl localhost:3333/api/plugins` returns CLI-installed plugins
- [ ] Plugin slugs are correct (e.g., `compound-engineering`, not `2.31.1`)
- [ ] Author names extracted correctly from object format

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>