### PR TITLE
fix(app): migrate activeWorkspaceProvider to AsyncNotifier with persistence

### DIFF
--- a/app/lib/features/chat/providers/chat_message_providers.dart
+++ b/app/lib/features/chat/providers/chat_message_providers.dart
@@ -1273,7 +1273,7 @@ class ChatMessagesNotifier extends StateNotifier<ChatMessagesState> {
       final modelApiValue = modelPref?.apiValue;
 
       // Read active workspace - prefer explicit param, fall back to sidebar filter
-      final activeWorkspace = workspaceId ?? _ref.read(activeWorkspaceProvider);
+      final activeWorkspace = workspaceId ?? _ref.read(activeWorkspaceProvider).valueOrNull;
 
       // Create stream context to hold mutable state across callbacks
       final ctx = _SendStreamContext(

--- a/app/lib/features/chat/providers/workspace_providers.dart
+++ b/app/lib/features/chat/providers/workspace_providers.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/providers/app_state_provider.dart';
 import 'package:parachute/core/providers/feature_flags_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../models/workspace.dart';
 import '../models/chat_session.dart';
 import '../services/workspace_service.dart';
@@ -24,15 +25,43 @@ final workspacesProvider = FutureProvider.autoDispose<List<Workspace>>((ref) asy
   return await service.listWorkspaces();
 });
 
+/// Notifier for the active workspace slug with SharedPreferences persistence.
+///
+/// Persists the selected workspace across app restarts. null = show all sessions.
+/// No autoDispose — app-level state that must outlive individual screens.
+class ActiveWorkspaceNotifier extends AsyncNotifier<String?> {
+  static const _key = 'parachute_active_workspace';
+
+  @override
+  Future<String?> build() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_key);
+  }
+
+  Future<void> setWorkspace(String? slug) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (slug != null) {
+      await prefs.setString(_key, slug);
+    } else {
+      await prefs.remove(_key);
+    }
+    state = AsyncData(slug);
+  }
+}
+
 /// Currently selected workspace slug (null = show all sessions).
-final activeWorkspaceProvider = StateProvider<String?>((ref) => null);
+///
+/// Persists across app restarts via SharedPreferences.
+final activeWorkspaceProvider = AsyncNotifierProvider<ActiveWorkspaceNotifier, String?>(
+  ActiveWorkspaceNotifier.new,
+);
 
 /// Sessions filtered by the active workspace.
 ///
 /// Derives from the already-fetched [chatSessionsProvider] via client-side
 /// filtering, eliminating a separate network request per workspace chip tap.
 final workspaceSessionsProvider = Provider.autoDispose<AsyncValue<List<ChatSession>>>((ref) {
-  final activeSlug = ref.watch(activeWorkspaceProvider);
+  final activeSlug = ref.watch(activeWorkspaceProvider).valueOrNull;
   final sessionsAsync = ref.watch(chatSessionsProvider);
 
   if (activeSlug == null) return sessionsAsync;

--- a/app/lib/features/chat/screens/agent_hub_screen.dart
+++ b/app/lib/features/chat/screens/agent_hub_screen.dart
@@ -689,7 +689,7 @@ class _AgentHubScreenState extends ConsumerState<AgentHubScreen> {
 
     // Set workspace if selected
     if (config.workspaceId != null) {
-      ref.read(activeWorkspaceProvider.notifier).state = config.workspaceId;
+      ref.read(activeWorkspaceProvider.notifier).setWorkspace(config.workspaceId);
     }
 
     if (mounted) {
@@ -730,7 +730,7 @@ class _AgentHubScreenState extends ConsumerState<AgentHubScreen> {
 
     // Set workspace if selected
     if (config.workspaceId != null) {
-      ref.read(activeWorkspaceProvider.notifier).state = config.workspaceId;
+      ref.read(activeWorkspaceProvider.notifier).setWorkspace(config.workspaceId);
     }
 
     if (mounted) {

--- a/app/lib/features/chat/screens/chat_screen.dart
+++ b/app/lib/features/chat/screens/chat_screen.dart
@@ -261,7 +261,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           agentType: _pendingAgentType,
           agentPath: _pendingAgentPath,
           trustLevel: _pendingTrustLevel,
-          workspaceId: ref.read(activeWorkspaceProvider),
+          workspaceId: ref.read(activeWorkspaceProvider).valueOrNull,
         );
 
     // Clear pending context, agentType, agentPath, and trustLevel after first message

--- a/app/lib/features/chat/screens/chat_shell.dart
+++ b/app/lib/features/chat/screens/chat_shell.dart
@@ -144,7 +144,7 @@ class _WorkspaceSidebar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final workspacesAsync = ref.watch(workspacesProvider);
-    final activeSlug = ref.watch(activeWorkspaceProvider);
+    final activeSlug = ref.watch(activeWorkspaceProvider).valueOrNull;
 
     return Container(
       color: isDark ? BrandColors.nightSurfaceElevated : BrandColors.softWhite,
@@ -202,7 +202,7 @@ class _WorkspaceSidebar extends ConsumerWidget {
             icon: Icons.chat_bubble_outline,
             isActive: activeSlug == null,
             isDark: isDark,
-            onTap: () => ref.read(activeWorkspaceProvider.notifier).state = null,
+            onTap: () => ref.read(activeWorkspaceProvider.notifier).setWorkspace(null),
           ),
 
           // Workspace list
@@ -234,7 +234,7 @@ class _WorkspaceSidebar extends ConsumerWidget {
                       isActive: activeSlug == ws.slug,
                       isDark: isDark,
                       subtitle: ws.model ?? ws.defaultTrustLevel,
-                      onTap: () => ref.read(activeWorkspaceProvider.notifier).state = ws.slug,
+                      onTap: () => ref.read(activeWorkspaceProvider.notifier).setWorkspace(ws.slug),
                       onEdit: () async {
                         final saved = await EditWorkspaceDialog.show(context, ws);
                         if (saved == true) ref.invalidate(workspacesProvider);
@@ -246,7 +246,7 @@ class _WorkspaceSidebar extends ConsumerWidget {
                         await service.deleteWorkspace(ws.slug);
                         ref.invalidate(workspacesProvider);
                         if (activeSlug == ws.slug) {
-                          ref.read(activeWorkspaceProvider.notifier).state = null;
+                          ref.read(activeWorkspaceProvider.notifier).setWorkspace(null);
                         }
                       },
                     );
@@ -325,7 +325,7 @@ class _WorkspaceSidebar extends ConsumerWidget {
       context,
       onCreated: (ws) {
         ref.invalidate(workspacesProvider);
-        ref.read(activeWorkspaceProvider.notifier).state = ws.slug;
+        ref.read(activeWorkspaceProvider.notifier).setWorkspace(ws.slug);
       },
     );
   }

--- a/app/lib/features/chat/widgets/session_list_panel.dart
+++ b/app/lib/features/chat/widgets/session_list_panel.dart
@@ -45,7 +45,7 @@ class _SessionListPanelState extends ConsumerState<SessionListPanel> {
 
   Widget _buildHeader(BuildContext context, bool isDark) {
     final layoutMode = ref.watch(chatLayoutModeProvider);
-    final activeSlug = ref.watch(activeWorkspaceProvider);
+    final activeSlug = ref.watch(activeWorkspaceProvider).valueOrNull;
     final workspacesAsync = ref.watch(workspacesProvider);
 
     return Container(
@@ -118,7 +118,7 @@ class _SessionListPanelState extends ConsumerState<SessionListPanel> {
   ) {
     final searchQuery = ref.watch(sessionSearchQueryProvider);
 
-    final activeWorkspace = ref.watch(activeWorkspaceProvider);
+    final activeWorkspace = ref.watch(activeWorkspaceProvider).valueOrNull;
 
     final AsyncValue<List<ChatSession>> sessionsAsync;
     if (_showArchived) {
@@ -251,7 +251,7 @@ class _SessionListPanelState extends ConsumerState<SessionListPanel> {
 
   void _showWorkspacePicker(bool isDark) {
     final workspacesAsync = ref.read(workspacesProvider);
-    final activeSlug = ref.read(activeWorkspaceProvider);
+    final activeSlug = ref.read(activeWorkspaceProvider).valueOrNull;
 
     showModalBottomSheet(
       context: context,
@@ -310,7 +310,7 @@ class _SessionListPanelState extends ConsumerState<SessionListPanel> {
                       ? Icon(Icons.check, color: isDark ? BrandColors.nightForest : BrandColors.forest)
                       : null,
                   onTap: () {
-                    ref.read(activeWorkspaceProvider.notifier).state = null;
+                    ref.read(activeWorkspaceProvider.notifier).setWorkspace(null);
                     Navigator.pop(sheetContext);
                   },
                 ),
@@ -363,7 +363,7 @@ class _SessionListPanelState extends ConsumerState<SessionListPanel> {
                                   ? Icon(Icons.check, color: isDark ? BrandColors.nightForest : BrandColors.forest)
                                   : null,
                               onTap: () {
-                                ref.read(activeWorkspaceProvider.notifier).state = ws.slug;
+                                ref.read(activeWorkspaceProvider.notifier).setWorkspace(ws.slug);
                                 Navigator.pop(sheetContext);
                               },
                             );

--- a/app/lib/features/chat/widgets/workspace_chip_row.dart
+++ b/app/lib/features/chat/widgets/workspace_chip_row.dart
@@ -19,7 +19,7 @@ class WorkspaceChipRow extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final workspacesAsync = ref.watch(workspacesProvider);
-    final activeSlug = ref.watch(activeWorkspaceProvider);
+    final activeSlug = ref.watch(activeWorkspaceProvider).valueOrNull;
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
     return workspacesAsync.when(
@@ -47,7 +47,7 @@ class WorkspaceChipRow extends ConsumerWidget {
                   isSelected: activeSlug == null,
                   isDark: isDark,
                   onTap: () {
-                    ref.read(activeWorkspaceProvider.notifier).state = null;
+                    ref.read(activeWorkspaceProvider.notifier).setWorkspace(null);
                     onSelected?.call(null);
                   },
                 ),
@@ -57,7 +57,7 @@ class WorkspaceChipRow extends ConsumerWidget {
                   isSelected: activeSlug == w.slug,
                   isDark: isDark,
                   onTap: () {
-                    ref.read(activeWorkspaceProvider.notifier).state = w.slug;
+                    ref.read(activeWorkspaceProvider.notifier).setWorkspace(w.slug);
                     onSelected?.call(w);
                   },
                 )),


### PR DESCRIPTION
## Summary

- Migrates `activeWorkspaceProvider` from `StateProvider<String?>` (in-memory only) to `AsyncNotifier<String?>` backed by SharedPreferences
- Selected workspace now persists across app restarts
- Follows the `AsyncNotifier` pattern already established in `app_state_provider.dart` (`ServerUrlNotifier`, `VaultPathNotifier`, `ApiKeyNotifier`, etc.)

Closes #104

## What changed

**`workspace_providers.dart`**
- Added `ActiveWorkspaceNotifier extends AsyncNotifier<String?>` with `build()` reading from SharedPreferences and `setWorkspace()` writing to it
- Replaced `StateProvider<String?>` with `AsyncNotifierProvider<ActiveWorkspaceNotifier, String?>`
- Updated `workspaceSessionsProvider` to use `.valueOrNull` on the now-async provider

**Call site updates** (7 files)
- Read sites: `ref.watch/read(activeWorkspaceProvider)` → `.valueOrNull`
- Write sites: `.notifier.state = value` → `.notifier.setWorkspace(value)`

Files updated: `workspace_providers.dart`, `workspace_chip_row.dart`, `chat_shell.dart`, `session_list_panel.dart`, `agent_hub_screen.dart`, `chat_screen.dart`, `chat_message_providers.dart`

## Notes

Fixes 1 (N+1 client-side filtering) and 3 (WorkspaceChipRow extraction) from the original issue were already implemented in a prior PR. This PR completes the remaining Fix 2.

## Testing

- `flutter analyze` passes with zero errors (207 pre-existing infos/warnings unchanged)
- Manually verify: select a workspace → close app → reopen → workspace filter should be restored

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)