### PR TITLE
fix(chat): AskUserQuestion dead code cleanup and safety fixes

### DIFF
--- a/app/lib/features/chat/models/chat_message.dart
+++ b/app/lib/features/chat/models/chat_message.dart
@@ -52,7 +52,7 @@ enum MessageRole { user, assistant }
 enum ContentType { text, toolUse, thinking, warning, userQuestion }
 
 /// Status of a user question (from AskUserQuestion tool)
-enum UserQuestionStatus { pending, answered, dismissed, timeout }
+enum UserQuestionStatus { pending, answered, timeout }
 
 /// Data for an AskUserQuestion tool call persisted in message content
 class UserQuestionData {
@@ -68,17 +68,6 @@ class UserQuestionData {
     this.status = UserQuestionStatus.pending,
   });
 
-  UserQuestionData copyWith({
-    Map<String, dynamic>? answers,
-    UserQuestionStatus? status,
-  }) {
-    return UserQuestionData(
-      toolUseId: toolUseId,
-      questions: questions,
-      answers: answers ?? this.answers,
-      status: status ?? this.status,
-    );
-  }
 }
 
 /// A tool call made by the assistant

--- a/app/lib/features/chat/models/stream_event.dart
+++ b/app/lib/features/chat/models/stream_event.dart
@@ -226,7 +226,7 @@ class StreamEvent {
   List<Map<String, dynamic>> get questions {
     final qs = data['questions'] as List<dynamic>?;
     if (qs == null) return [];
-    return qs.cast<Map<String, dynamic>>();
+    return qs.whereType<Map<String, dynamic>>().toList();
   }
 
   // Typed error event accessors

--- a/app/lib/features/chat/providers/chat_message_providers.dart
+++ b/app/lib/features/chat/providers/chat_message_providers.dart
@@ -1823,17 +1823,12 @@ class ChatMessagesNotifier extends StateNotifier<ChatMessagesState> {
         answers: answers,
       );
 
-      if (success) {
-        // Clear the pending question
-        state = state.copyWith(clearPendingUserQuestion: true);
-        debugPrint('[ChatMessagesNotifier] Question answered successfully');
-      } else {
-        // Backend likely timed out — clear the stale floating card.
-        // The inline card in the transcript will show the correct status
-        // when the session is reloaded.
-        debugPrint('[ChatMessagesNotifier] Answer rejected (question likely expired), clearing');
-        state = state.copyWith(clearPendingUserQuestion: true);
-      }
+      // Clear the pending question regardless of outcome. If rejected, the
+      // inline card in the transcript will show the correct status on reload.
+      state = state.copyWith(clearPendingUserQuestion: true);
+      debugPrint(success
+          ? '[ChatMessagesNotifier] Question answered successfully'
+          : '[ChatMessagesNotifier] Answer rejected (question likely expired), clearing');
 
       return success;
     } catch (e) {

--- a/app/lib/features/chat/widgets/inline_user_question_card.dart
+++ b/app/lib/features/chat/widgets/inline_user_question_card.dart
@@ -254,7 +254,6 @@ class _InlineUserQuestionCardState
       case UserQuestionStatus.pending:
         return isDark ? BrandColors.nightTurquoise : BrandColors.turquoise;
       case UserQuestionStatus.timeout:
-      case UserQuestionStatus.dismissed:
         return isDark ? Colors.orange.shade700 : Colors.orange.shade300;
     }
   }
@@ -281,10 +280,6 @@ class _InlineUserQuestionCardState
         case UserQuestionStatus.timeout:
           icon = Icons.timer_off_outlined;
           label = 'Expired';
-          color = isDark ? Colors.orange.shade300 : Colors.orange.shade700;
-        case UserQuestionStatus.dismissed:
-          icon = Icons.close;
-          label = 'Dismissed';
           color = isDark ? Colors.orange.shade300 : Colors.orange.shade700;
       }
     }


### PR DESCRIPTION
## Summary

Three small cleanup items from the PR #84 code review:

- Remove `UserQuestionStatus.dismissed` from the enum — it was never produced by any code path. Also removes its two exhaustive-switch arms in `inline_user_question_card.dart`.
- Remove `UserQuestionData.copyWith()` — zero callers; the only `copyWith` in scope is `ChatMessage.copyWith`.
- Replace `qs.cast<Map<String, dynamic>>()` with `qs.whereType<Map<String, dynamic>>().toList()` in `stream_event.dart` — `cast()` is lazy and throws `TypeError` on first access if any element is malformed; `whereType` silently filters instead.
- Collapse the redundant if/else in `answerQuestion()` — both branches cleared `pendingUserQuestion`, only the debug log differed.

Net: −21 lines of dead/redundant code.

Closes #90

## Testing

- `flutter analyze` passes (zero new errors/warnings introduced)
- Pure dead-code removal and one-line safety swap — no behavioral changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)