### PR TITLE
feat(chat): generate session title/summary from server event loop

### DIFF
--- a/computer/parachute/core/session_summarizer.py
+++ b/computer/parachute/core/session_summarizer.py
@@ -1,0 +1,219 @@
+"""
+Session Title and Summary Generation
+
+Generates AI titles and summaries for chat sessions. Called as a fire-and-forget
+background task from the orchestrator's streaming event loop after each exchange.
+
+This runs server-side, so it works uniformly for direct and sandboxed sessions
+without any hook registration or Python path portability concerns.
+"""
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# System prompt for the summarizer agent
+SUMMARIZER_SYSTEM_PROMPT = """You are a concise summarizer for conversation activity logs.
+
+Your job is to summarize each conversation exchange in 1-3 sentences, capturing:
+- What was accomplished or discussed
+- Any decisions made
+- Key insights or realizations
+
+Also suggest a title for the conversation (3-8 words).
+
+Always respond in this exact format:
+SUMMARY: <your summary>
+TITLE: <title or NO_CHANGE if current title is still accurate>
+
+Be concise. Focus on what matters for future context."""
+
+# Simple file-based cache for daily summarizer session
+_SUMMARIZER_CACHE_FILE = ".activity_summarizer_sessions.json"
+
+# Cadence control: don't run the summarizer on every exchange
+_TITLE_UPDATE_EXCHANGES = {1, 3, 5}  # Always fire on these
+_TITLE_UPDATE_INTERVAL = 10           # After 5, fire every 10th
+
+
+def _should_update(exchange_number: int) -> bool:
+    """Return True if this exchange warrants a title/summary update."""
+    return (
+        exchange_number in _TITLE_UPDATE_EXCHANGES
+        or (exchange_number > 5 and exchange_number % _TITLE_UPDATE_INTERVAL == 0)
+    )
+
+
+async def get_daily_summarizer_session(vault_path: Path, date: str) -> Optional[str]:
+    """Get the cached summarizer session ID for a given date."""
+    cache_path = vault_path / "Daily" / ".activity" / _SUMMARIZER_CACHE_FILE
+    if not cache_path.exists():
+        return None
+    try:
+        cache = json.loads(cache_path.read_text())
+        return cache.get(date)
+    except Exception as e:
+        logger.debug(f"Failed to read summarizer cache: {e}")
+        return None
+
+
+async def save_daily_summarizer_session(vault_path: Path, date: str, session_id: str) -> None:
+    """Persist the summarizer session ID for a given date."""
+    cache_dir = vault_path / "Daily" / ".activity"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = cache_dir / _SUMMARIZER_CACHE_FILE
+
+    cache: dict = {}
+    if cache_path.exists():
+        try:
+            cache = json.loads(cache_path.read_text())
+        except Exception as e:
+            logger.debug(f"Failed to read existing summarizer cache: {e}")
+
+    cache[date] = session_id
+    cache_path.write_text(json.dumps(cache, indent=2))
+
+
+async def _call_summarizer(
+    session_title: Optional[str],
+    user_message: str,
+    assistant_response: str,
+    tool_calls: list[str],
+    exchange_number: int,
+    vault_path: Path,
+    claude_token: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Run the summarizer Claude session. Returns (summary, new_title).
+
+    Both may be None on failure or if the model returns NO_CHANGE.
+    """
+    from parachute.core.claude_sdk import query_streaming
+
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    resume_session_id = await get_daily_summarizer_session(vault_path, today)
+
+    tools_str = ", ".join(tool_calls) if tool_calls else "None"
+    truncated_user = user_message[:1000] + ("... [truncated]" if len(user_message) > 1000 else "")
+    truncated_response = assistant_response[:2000] + ("... [truncated]" if len(assistant_response) > 2000 else "")
+
+    prompt = f"""Summarize this conversation exchange:
+
+Current session title: {session_title or "None"}
+Exchange #{exchange_number}
+
+---
+
+User: {truncated_user}
+
+Tools used: {tools_str}
+Assistant: {truncated_response}
+
+---
+
+Respond in this exact format:
+SUMMARY: <your 1-3 sentence summary>
+TITLE: <new title or NO_CHANGE>"""
+
+    result_text = ""
+    new_session_id = None
+
+    async for event in query_streaming(
+        prompt=prompt,
+        system_prompt=SUMMARIZER_SYSTEM_PROMPT,
+        use_claude_code_preset=False,
+        tools=[],
+        resume=resume_session_id,
+        setting_sources=[],
+        claude_token=claude_token,
+    ):
+        if event.get("type") == "system" and event.get("session_id"):
+            new_session_id = event["session_id"]
+        if event.get("type") == "assistant" and event.get("message"):
+            for block in event["message"].get("content", []):
+                if block.get("type") == "text":
+                    result_text += block.get("text", "")
+
+    if new_session_id and not resume_session_id:
+        await save_daily_summarizer_session(vault_path, today, new_session_id)
+
+    summary: Optional[str] = None
+    title: Optional[str] = None
+    for line in result_text.strip().split("\n"):
+        if line.startswith("SUMMARY:"):
+            summary = line[8:].strip() or None
+        elif line.startswith("TITLE:"):
+            raw = line[6:].strip()
+            if raw and raw != "NO_CHANGE":
+                title = raw
+
+    return summary, title
+
+
+async def summarize_session(
+    session_id: str,
+    message: str,
+    result_text: str,
+    tool_calls: list[str],
+    exchange_number: int,
+    session_title: Optional[str],
+    title_source: Optional[str],
+    database: object,
+    vault_path: Path,
+    claude_token: Optional[str],
+) -> None:
+    """Generate and persist title/summary for a session exchange.
+
+    Fire-and-forget: all exceptions are caught, never raises.
+    Respects the title_source guard — never overwrites user-set titles.
+    """
+    try:
+        if not _should_update(exchange_number):
+            return
+
+        summary, new_title = await _call_summarizer(
+            session_title=session_title,
+            user_message=message,
+            assistant_response=result_text,
+            tool_calls=tool_calls,
+            exchange_number=exchange_number,
+            vault_path=vault_path,
+            claude_token=claude_token,
+        )
+
+        # Title guard: never overwrite user-set titles
+        title_to_write = (
+            new_title
+            if title_source != "user" and new_title and new_title != session_title
+            else None
+        )
+
+        if not title_to_write and not summary:
+            return
+
+        from parachute.db.database import SessionUpdate
+
+        update = SessionUpdate()
+        if title_to_write:
+            session = await database.get_session(session_id)
+            if session:
+                metadata = dict(session.metadata or {})
+                metadata["title_source"] = "ai"
+                update.title = title_to_write
+                update.metadata = metadata
+        if summary:
+            update.summary = summary
+
+        if update.title is not None or update.summary is not None:
+            await database.update_session(session_id, update)
+            logger.debug(
+                f"Updated session {session_id[:8]}: "
+                f"title={'set' if update.title else 'unchanged'}, "
+                f"summary={'set' if update.summary else 'unchanged'}"
+            )
+
+    except Exception as e:
+        logger.debug(f"Session summarizer failed for {session_id[:8]}: {e}")

--- a/computer/parachute/hooks/activity_hook.py
+++ b/computer/parachute/hooks/activity_hook.py
@@ -1,29 +1,15 @@
 #!/usr/bin/env python3
 """
-Activity Hook - logs all session exchanges with AI-generated summaries.
+Activity Hook - logs session exchanges to Daily/.activity/ JSONL files.
 
 This script is triggered by the SDK's Stop hook after each response.
-It reads the transcript, summarizes the last exchange, and logs it.
+It reads the transcript and appends an entry to the daily activity log.
+
+Note: Title and summary generation has moved to the server's streaming event
+loop (session_summarizer.py). This hook handles activity logging only.
 
 Usage: python -m parachute.hooks.activity_hook
        (SDK passes hook input via stdin)
-
-Hook Configuration (in .claude/settings.json):
-{
-  "hooks": {
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python -m parachute.hooks.activity_hook"
-          }
-        ]
-      }
-    ]
-  }
-}
 """
 
 import asyncio
@@ -36,25 +22,6 @@ from pathlib import Path
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
-
-# System prompt for the summarizer agent
-SUMMARIZER_SYSTEM_PROMPT = """You are a concise summarizer for conversation activity logs.
-
-Your job is to summarize each conversation exchange in 1-3 sentences, capturing:
-- What was accomplished or discussed
-- Any decisions made
-- Key insights or realizations
-
-Also suggest a title for the conversation (3-8 words).
-
-Always respond in this exact format:
-SUMMARY: <your summary>
-TITLE: <title or NO_CHANGE if current title is still accurate>
-
-Be concise. Focus on what matters for future context."""
-
-# Simple file-based cache for daily summarizer session
-SUMMARIZER_CACHE_FILE = ".activity_summarizer_sessions.json"
 
 
 def main():
@@ -72,10 +39,9 @@ def main():
 
 async def handle_stop_hook(hook_input: dict) -> None:
     """
-    Handle the Stop hook event.
+    Handle the Stop hook event — append to Daily/.activity/ log.
 
-    Args:
-        hook_input: JSON from SDK containing transcript_path, session_id, etc.
+    Title and summary generation is handled server-side by session_summarizer.py.
     """
     try:
         transcript_path = Path(hook_input.get("transcript_path", ""))
@@ -92,75 +58,25 @@ async def handle_stop_hook(hook_input: dict) -> None:
         # 1. Read the last exchange from the transcript
         exchange = read_last_exchange(transcript_path)
         if not exchange:
-            logger.debug("No exchange to summarize")
+            logger.debug("No exchange found in transcript")
             return
 
-        exchange_num = exchange.get("exchange_number", 1)
-
-        # 2. Decide whether this exchange warrants a title update
-        if not _should_update_title(exchange_num):
-            return
-
-        # 3. Fetch session once — reuse for title, metadata, and agent_type
+        # 2. Fetch session for agent_type (used in activity log entry)
         session = await _get_session(session_id)
         session_title = session.title if session else None
         agent_type = session.get_agent_type() if session else None
-        title_source = (
-            session.metadata.get("title_source")
-            if session and session.metadata
-            else None
-        )
-        user_renamed = title_source == "user"
 
-        # 4. Call the summarizer (uses SDK internally)
-        summary, new_title = await call_summarizer(
-            session_id=session_id,
-            session_title=session_title,
-            user_message=exchange["user_message"],
-            assistant_response=exchange["assistant_response"],
-            tools_used=exchange.get("tools_used", []),
-            thinking=exchange.get("thinking", ""),
-            exchange_number=exchange_num,
-        )
-
-        # 5. Append to activity log
+        # 3. Append to daily activity log
         await append_activity_log(
             session_id=session_id,
             session_title=session_title,
             agent_type=agent_type,
-            exchange_number=exchange_num,
-            summary=summary,
+            exchange_number=exchange.get("exchange_number", 1),
+            summary=None,  # Summary written server-side by session_summarizer
         )
-
-        # 6. Persist title and/or summary via the server API
-        title_to_write = (
-            new_title
-            if not user_renamed and new_title and new_title != "NO_CHANGE" and new_title != session_title
-            else None
-        )
-        if title_to_write or summary:
-            await update_session_metadata(
-                session_id,
-                title=title_to_write,
-                summary=summary or None,
-            )
 
     except Exception as e:
-        # Fire-and-forget - log but don't fail
         logger.warning(f"Activity hook failed: {e}")
-
-
-# Cadence control: don't call Haiku on every exchange
-_TITLE_UPDATE_EXCHANGES = {1, 3, 5}  # Always fire on these
-_TITLE_UPDATE_INTERVAL = 10           # After 5, fire every 10th
-
-
-def _should_update_title(exchange_number: int) -> bool:
-    """Decide whether this exchange warrants a title update via Haiku."""
-    return (
-        exchange_number in _TITLE_UPDATE_EXCHANGES
-        or (exchange_number > 5 and exchange_number % _TITLE_UPDATE_INTERVAL == 0)
-    )
 
 
 def read_last_exchange(transcript_path: Path) -> Optional[dict]:
@@ -292,126 +208,6 @@ async def _get_session(session_id: str) -> Optional[Any]:
     return None
 
 
-async def call_summarizer(
-    session_id: str,
-    session_title: Optional[str],
-    user_message: str,
-    assistant_response: str,
-    tools_used: list[str],
-    thinking: str,
-    exchange_number: int,
-) -> tuple[str, str]:
-    """
-    Call the daily summarizer agent to summarize this exchange.
-
-    Uses SDK query_streaming() with resume for session continuity.
-    """
-    from parachute.config import get_settings
-    from parachute.core.claude_sdk import query_streaming
-
-    settings = get_settings()
-    vault_path = settings.vault_path
-
-    # Get or create today's summarizer session
-    today = datetime.utcnow().strftime("%Y-%m-%d")
-    resume_session_id = await get_daily_summarizer_session(vault_path, today)
-
-    # Build the prompt
-    tools_str = ", ".join(tools_used) if tools_used else "None"
-    truncated_response = assistant_response[:2000]
-    if len(assistant_response) > 2000:
-        truncated_response += "... [truncated]"
-
-    truncated_user = user_message[:1000]
-    if len(user_message) > 1000:
-        truncated_user += "... [truncated]"
-
-    prompt = f"""Summarize this conversation exchange:
-
-Current session title: {session_title or "None"}
-Exchange #{exchange_number}
-
----
-
-User: {truncated_user}
-
-Tools used: {tools_str}
-Assistant: {truncated_response}
-
----
-
-Respond in this exact format:
-SUMMARY: <your 1-3 sentence summary>
-TITLE: <new title or NO_CHANGE>"""
-
-    # Call the SDK
-    result_text = ""
-    new_session_id = None
-
-    async for event in query_streaming(
-        prompt=prompt,
-        system_prompt=SUMMARIZER_SYSTEM_PROMPT,
-        use_claude_code_preset=False,
-        tools=[],
-        resume=resume_session_id,
-        setting_sources=[],  # Don't load CLAUDE.md
-        claude_token=settings.claude_code_oauth_token,
-    ):
-        if event.get("type") == "system" and event.get("session_id"):
-            new_session_id = event["session_id"]
-
-        if event.get("type") == "assistant" and event.get("message"):
-            for block in event["message"].get("content", []):
-                if block.get("type") == "text":
-                    result_text += block.get("text", "")
-
-    # Save session ID for today if new
-    if new_session_id and not resume_session_id:
-        await save_daily_summarizer_session(vault_path, today, new_session_id)
-
-    # Parse response
-    summary = ""
-    title = "NO_CHANGE"
-    for line in result_text.strip().split("\n"):
-        if line.startswith("SUMMARY:"):
-            summary = line[8:].strip()
-        elif line.startswith("TITLE:"):
-            title = line[6:].strip()
-
-    return summary, title
-
-
-async def get_daily_summarizer_session(vault_path: Path, date: str) -> Optional[str]:
-    """Get the summarizer session ID for a given date."""
-    cache_path = vault_path / "Daily" / ".activity" / SUMMARIZER_CACHE_FILE
-    if not cache_path.exists():
-        return None
-
-    try:
-        cache = json.loads(cache_path.read_text())
-        return cache.get(date)
-    except Exception as e:
-        logger.debug(f"Failed to read summarizer cache: {e}")
-        return None
-
-
-async def save_daily_summarizer_session(vault_path: Path, date: str, session_id: str) -> None:
-    """Save the summarizer session ID for a given date."""
-    cache_dir = vault_path / "Daily" / ".activity"
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    cache_path = cache_dir / SUMMARIZER_CACHE_FILE
-
-    cache = {}
-    if cache_path.exists():
-        try:
-            cache = json.loads(cache_path.read_text())
-        except Exception as e:
-            logger.debug(f"Failed to read existing summarizer cache: {e}")
-
-    cache[date] = session_id
-    cache_path.write_text(json.dumps(cache, indent=2))
-
-
 async def append_activity_log(
     session_id: str,
     session_title: Optional[str],
@@ -441,34 +237,6 @@ async def append_activity_log(
 
     with open(log_file, "a") as f:
         f.write(json.dumps(entry) + "\n")
-
-
-async def update_session_metadata(
-    session_id: str,
-    *,
-    title: Optional[str] = None,
-    summary: Optional[str] = None,
-) -> None:
-    """Update session title and/or summary via the Parachute server API.
-
-    The server handles the title_source guard (won't overwrite user-set titles).
-    Fire-and-forget: failures are logged but never raised.
-    """
-    payload = {}
-    if title is not None:
-        payload["title"] = title
-    if summary is not None:
-        payload["summary"] = summary
-    if not payload:
-        return
-    try:
-        import httpx
-
-        url = f"{_get_server_url()}/api/chat/{session_id}/metadata"
-        async with httpx.AsyncClient() as client:
-            await client.patch(url, json=payload, timeout=5.0)
-    except Exception as e:
-        logger.debug(f"Failed to update session metadata: {e}")
 
 
 if __name__ == "__main__":

--- a/computer/tests/unit/test_session_summarizer.py
+++ b/computer/tests/unit/test_session_summarizer.py
@@ -1,0 +1,387 @@
+"""
+Tests for session_summarizer.py — server-side title/summary generation.
+
+Covers:
+- _should_update() cadence (exchanges {1, 3, 5}, every 10th after that)
+- summarize_session() skips when exchange not in cadence
+- summarize_session() respects title_source == "user" guard
+- summarize_session() writes title + summary when appropriate
+- summarize_session() never raises — fire-and-forget safety
+- Daily summarizer session cache (get/save)
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from parachute.core.session_summarizer import (
+    _should_update,
+    get_daily_summarizer_session,
+    save_daily_summarizer_session,
+    summarize_session,
+)
+
+
+# ---------------------------------------------------------------------------
+# _should_update cadence tests
+# ---------------------------------------------------------------------------
+
+
+class TestShouldUpdate:
+    def test_fires_on_exchange_1(self):
+        assert _should_update(1) is True
+
+    def test_fires_on_exchange_3(self):
+        assert _should_update(3) is True
+
+    def test_fires_on_exchange_5(self):
+        assert _should_update(5) is True
+
+    def test_skips_exchange_2(self):
+        assert _should_update(2) is False
+
+    def test_skips_exchange_4(self):
+        assert _should_update(4) is False
+
+    def test_skips_exchange_6(self):
+        assert _should_update(6) is False
+
+    def test_skips_exchange_7_through_9(self):
+        for n in [7, 8, 9]:
+            assert _should_update(n) is False
+
+    def test_fires_on_exchange_10(self):
+        assert _should_update(10) is True
+
+    def test_skips_exchange_11_through_19(self):
+        for n in range(11, 20):
+            assert _should_update(n) is False
+
+    def test_fires_on_exchange_20(self):
+        assert _should_update(20) is True
+
+    def test_fires_on_exchange_30(self):
+        assert _should_update(30) is True
+
+    def test_skips_exchange_25(self):
+        assert _should_update(25) is False
+
+
+# ---------------------------------------------------------------------------
+# Daily summarizer session cache tests
+# ---------------------------------------------------------------------------
+
+
+class TestDailySummarizerSessionCache:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_cache_file(self, tmp_path):
+        result = await get_daily_summarizer_session(tmp_path, "2026-02-23")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_save_and_retrieve_session_id(self, tmp_path):
+        await save_daily_summarizer_session(tmp_path, "2026-02-23", "sess_abc123")
+        result = await get_daily_summarizer_session(tmp_path, "2026-02-23")
+        assert result == "sess_abc123"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_different_date(self, tmp_path):
+        await save_daily_summarizer_session(tmp_path, "2026-02-23", "sess_abc123")
+        result = await get_daily_summarizer_session(tmp_path, "2026-02-24")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_overwrites_existing_session_for_same_date(self, tmp_path):
+        await save_daily_summarizer_session(tmp_path, "2026-02-23", "sess_first")
+        await save_daily_summarizer_session(tmp_path, "2026-02-23", "sess_second")
+        result = await get_daily_summarizer_session(tmp_path, "2026-02-23")
+        assert result == "sess_second"
+
+    @pytest.mark.asyncio
+    async def test_preserves_other_dates(self, tmp_path):
+        await save_daily_summarizer_session(tmp_path, "2026-02-22", "sess_day1")
+        await save_daily_summarizer_session(tmp_path, "2026-02-23", "sess_day2")
+        assert await get_daily_summarizer_session(tmp_path, "2026-02-22") == "sess_day1"
+        assert await get_daily_summarizer_session(tmp_path, "2026-02-23") == "sess_day2"
+
+    @pytest.mark.asyncio
+    async def test_cache_file_is_valid_json(self, tmp_path):
+        await save_daily_summarizer_session(tmp_path, "2026-02-23", "sess_xyz")
+        cache_path = tmp_path / "Daily" / ".activity" / ".activity_summarizer_sessions.json"
+        data = json.loads(cache_path.read_text())
+        assert data == {"2026-02-23": "sess_xyz"}
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_corrupted_cache(self, tmp_path):
+        cache_dir = tmp_path / "Daily" / ".activity"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / ".activity_summarizer_sessions.json").write_text("not valid json{{{")
+        result = await get_daily_summarizer_session(tmp_path, "2026-02-23")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# summarize_session tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_db(session_title=None, title_source=None, session_exists=True):
+    """Build a minimal mock database for summarize_session tests."""
+    db = MagicMock()
+
+    if session_exists:
+        mock_session = MagicMock()
+        mock_session.title = session_title
+        mock_session.metadata = {"title_source": title_source} if title_source else {}
+        db.get_session = AsyncMock(return_value=mock_session)
+    else:
+        db.get_session = AsyncMock(return_value=None)
+
+    db.update_session = AsyncMock()
+    return db
+
+
+class TestSummarizeSession:
+    @pytest.mark.asyncio
+    async def test_skips_on_non_cadence_exchange(self, tmp_path):
+        """Does not call the summarizer on exchanges outside the cadence."""
+        db = _make_mock_db()
+        with patch(
+            "parachute.core.session_summarizer._call_summarizer",
+            new_callable=AsyncMock,
+        ) as mock_call:
+            await summarize_session(
+                session_id="sess_001",
+                message="Hello",
+                result_text="Hi there",
+                tool_calls=[],
+                exchange_number=2,  # not in cadence
+                session_title=None,
+                title_source=None,
+                database=db,
+                vault_path=tmp_path,
+                claude_token=None,
+            )
+
+        mock_call.assert_not_called()
+        db.update_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_writes_title_and_summary_on_first_exchange(self, tmp_path):
+        """Writes both title and summary when summarizer returns both."""
+        db = _make_mock_db(session_title=None, title_source=None)
+
+        with patch(
+            "parachute.core.session_summarizer._call_summarizer",
+            new_callable=AsyncMock,
+            return_value=("User asked about Python. Claude explained basics.", "Python Basics Chat"),
+        ):
+            await summarize_session(
+                session_id="sess_001",
+                message="What is Python?",
+                result_text="Python is a programming language.",
+                tool_calls=[],
+                exchange_number=1,
+                session_title=None,
+                title_source=None,
+                database=db,
+                vault_path=tmp_path,
+                claude_token=None,
+            )
+
+        db.update_session.assert_called_once()
+        call_args = db.update_session.call_args
+        assert call_args[0][0] == "sess_001"
+        update = call_args[0][1]
+        assert update.title == "Python Basics Chat"
+        assert update.summary == "User asked about Python. Claude explained basics."
+        assert update.metadata["title_source"] == "ai"
+
+    @pytest.mark.asyncio
+    async def test_respects_user_title_source_guard(self, tmp_path):
+        """Does not overwrite title when title_source == 'user'."""
+        db = _make_mock_db(session_title="My Custom Title", title_source="user")
+
+        with patch(
+            "parachute.core.session_summarizer._call_summarizer",
+            new_callable=AsyncMock,
+            return_value=("Summary text.", "AI Override Title"),
+        ):
+            await summarize_session(
+                session_id="sess_002",
+                message="Some question",
+                result_text="Some answer",
+                tool_calls=[],
+                exchange_number=1,
+                session_title="My Custom Title",
+                title_source="user",
+                database=db,
+                vault_path=tmp_path,
+                claude_token=None,
+            )
+
+        db.update_session.assert_called_once()
+        update = db.update_session.call_args[0][1]
+        # Title must NOT be set — user title is protected
+        assert update.title is None
+        # Summary should still be written
+        assert update.summary == "Summary text."
+
+    @pytest.mark.asyncio
+    async def test_skips_update_when_title_unchanged(self, tmp_path):
+        """Does not write title when summarizer returns the same title."""
+        db = _make_mock_db(session_title="Existing Title", title_source="ai")
+
+        with patch(
+            "parachute.core.session_summarizer._call_summarizer",
+            new_callable=AsyncMock,
+            return_value=("New summary.", "Existing Title"),  # same title
+        ):
+            await summarize_session(
+                session_id="sess_003",
+                message="Question",
+                result_text="Answer",
+                tool_calls=[],
+                exchange_number=3,
+                session_title="Existing Title",
+                title_source="ai",
+                database=db,
+                vault_path=tmp_path,
+                claude_token=None,
+            )
+
+        db.update_session.assert_called_once()
+        update = db.update_session.call_args[0][1]
+        assert update.title is None  # unchanged title not re-written
+        assert update.summary == "New summary."
+
+    @pytest.mark.asyncio
+    async def test_writes_only_summary_when_no_title(self, tmp_path):
+        """Only writes summary when summarizer returns None title."""
+        db = _make_mock_db()
+
+        with patch(
+            "parachute.core.session_summarizer._call_summarizer",
+            new_callable=AsyncMock,
+            return_value=("Just a summary.", None),
+        ):
+            await summarize_session(
+                session_id="sess_004",
+                message="Question",
+                result_text="Answer",
+                tool_calls=[],
+                exchange_number=1,
+                session_title="Some Title",
+                title_source="ai",
+                database=db,
+                vault_path=tmp_path,
+                claude_token=None,
+            )
+
+        db.update_session.assert_called_once()
+        update = db.update_session.call_args[0][1]
+        assert update.title is None
+        assert update.summary == "Just a summary."
+
+    @pytest.mark.asyncio
+    async def test_skips_db_write_when_both_none(self, tmp_path):
+        """Does not call update_session when summarizer returns (None, None)."""
+        db = _make_mock_db()
+
+        with patch(
+            "parachute.core.session_summarizer._call_summarizer",
+            new_callable=AsyncMock,
+            return_value=(None, None),
+        ):
+            await summarize_session(
+                session_id="sess_005",
+                message="Question",
+                result_text="Answer",
+                tool_calls=[],
+                exchange_number=1,
+                session_title=None,
+                title_source=None,
+                database=db,
+                vault_path=tmp_path,
+                claude_token=None,
+            )
+
+        db.update_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_never_raises_on_summarizer_exception(self, tmp_path):
+        """summarize_session catches all exceptions and never raises."""
+        db = _make_mock_db()
+
+        with patch(
+            "parachute.core.session_summarizer._call_summarizer",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("SDK exploded"),
+        ):
+            # Must not raise
+            await summarize_session(
+                session_id="sess_006",
+                message="Question",
+                result_text="Answer",
+                tool_calls=[],
+                exchange_number=1,
+                session_title=None,
+                title_source=None,
+                database=db,
+                vault_path=tmp_path,
+                claude_token=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_never_raises_on_db_exception(self, tmp_path):
+        """summarize_session catches DB errors and never raises."""
+        db = _make_mock_db()
+        db.update_session = AsyncMock(side_effect=Exception("DB connection lost"))
+
+        with patch(
+            "parachute.core.session_summarizer._call_summarizer",
+            new_callable=AsyncMock,
+            return_value=("Summary.", "New Title"),
+        ):
+            await summarize_session(
+                session_id="sess_007",
+                message="Question",
+                result_text="Answer",
+                tool_calls=[],
+                exchange_number=1,
+                session_title=None,
+                title_source=None,
+                database=db,
+                vault_path=tmp_path,
+                claude_token=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_skips_title_write_when_session_not_found(self, tmp_path):
+        """When get_session returns None, title is not written but summary is."""
+        db = _make_mock_db(session_exists=False)
+
+        with patch(
+            "parachute.core.session_summarizer._call_summarizer",
+            new_callable=AsyncMock,
+            return_value=("Summary text.", "New Title"),
+        ):
+            await summarize_session(
+                session_id="sess_008",
+                message="Question",
+                result_text="Answer",
+                tool_calls=[],
+                exchange_number=1,
+                session_title=None,
+                title_source=None,
+                database=db,
+                vault_path=tmp_path,
+                claude_token=None,
+            )
+
+        db.update_session.assert_called_once()
+        update = db.update_session.call_args[0][1]
+        # Title skipped (session not found to fetch for metadata update)
+        assert update.title is None
+        assert update.summary == "Summary text."

--- a/docs/plans/2026-02-23-feat-session-title-summary-server-event-loop-plan.md
+++ b/docs/plans/2026-02-23-feat-session-title-summary-server-event-loop-plan.md
@@ -1,0 +1,157 @@
+---
+title: "feat: generate session title/summary from server streaming event loop"
+type: feat
+date: 2026-02-23
+issue: 122
+---
+
+# feat: Session Title/Summary via Server Event Loop
+
+## Overview
+
+Move automatic session title and summary generation from a Stop hook (`activity_hook.py`) into the server's streaming event loop. The server already processes every session's events — triggering summarization there works uniformly for direct and sandboxed sessions, with no hook registration, no Python path portability problems, and no settings.json complexity.
+
+## Problem Statement
+
+The current Stop hook approach has two structural problems:
+
+1. **Hook portability**: The hook command embeds a host-specific Python path. Sandboxed sessions run inside Docker where that path doesn't exist — hooks silently fail and titles/summaries are never generated for sandboxed sessions.
+2. **Hook registration**: The vault's `.claude/settings.json` must be created, maintained, and kept in sync with the installed Python path — operational complexity that grows over time.
+
+## Solution
+
+The orchestrator's `run_streaming()` already yields every event including the `result` event (session complete). A fire-and-forget `asyncio.create_task()` launched just before `yield DoneEvent()` runs summarization as a background task. By this point all data needed is already in memory — no JSONL transcript parsing required.
+
+## Technical Approach
+
+### What Already Exists (Keep)
+
+- `PATCH /api/chat/{session_id}/metadata` endpoint (`api/sessions.py:249`) — the write path, enforces `title_source == "user"` guard
+- `update_session_title` / `update_session_summary` MCP tools — for agent-native use (Claude calling them explicitly)
+- `call_summarizer()` in `activity_hook.py:295` — the Claude SDK call that generates title/summary text; reuse this logic
+- `_should_update_title()` in `activity_hook.py:158` — exchange cadence logic ({1, 3, 5} then every 10th); reuse
+- `get_daily_summarizer_session()` / `save_daily_summarizer_session()` — per-day summarizer session continuity; reuse
+- Activity logging in `handle_stop_hook()` — unrelated to title/summary, stays in the hook
+
+### New Module: `parachute/core/session_summarizer.py`
+
+Extract the title/summary logic from `activity_hook.py` into a proper server-side module. This avoids the orchestrator importing from `parachute/hooks/` (which is a subprocess utility, not a library), and makes the logic testable in isolation.
+
+**Contents:**
+- `SUMMARIZER_SYSTEM_PROMPT` — moved from `activity_hook.py:41`
+- `_should_update_title(exchange_number: int) -> bool` — moved from `activity_hook.py:158`
+- `get_exchange_number(session: Session) -> int` — computes exchange number from `session.message_count`
+- `build_summarizer_prompt(session, message, result_text, tool_calls, exchange_number) -> str` — builds the prompt
+- `call_summarizer(session, prompt, settings) -> tuple[str | None, str | None]` — runs the Claude SDK query, returns `(title, summary)`
+- `summarize_session(session_id, message, result_text, tool_calls, database, settings) -> None` — the top-level async function called from the orchestrator; handles exchange gating, summarization, and writing
+
+### Orchestrator Change (`orchestrator.py`)
+
+Insert a single fire-and-forget task just before `yield DoneEvent()` at line 1299:
+
+```python
+# computer/parachute/core/orchestrator.py (near line 1299)
+# Kick off title/summary generation as a background task
+if captured_session_id and session:
+    from parachute.core.session_summarizer import summarize_session
+    asyncio.create_task(
+        summarize_session(
+            session_id=captured_session_id,
+            message=message,
+            result_text=result_text,
+            tool_calls=tool_calls or [],
+            database=self.database,
+            settings=self.settings,
+        )
+    )
+
+yield DoneEvent(...).model_dump(by_alias=True)
+```
+
+**Exchange number computation:** `session.message_count` counts prior messages. Each exchange = 2 messages (user + assistant). Exchange number = `(session.message_count // 2) + 1`.
+
+**Write path:** `summarize_session()` writes directly via `self.database.update_session()` — no HTTP roundtrip. Must replicate the `title_source != "user"` guard (same logic as the PATCH endpoint).
+
+### activity_hook.py Changes
+
+Remove from `handle_stop_hook()`:
+- Steps 3 (`_should_update_title` check), 5 (`call_summarizer`), and 7 (`update_session_metadata` for title/summary)
+- The `_should_update_title`, `SUMMARIZER_SYSTEM_PROMPT` constants (moved to `session_summarizer.py`)
+- The `_get_session()` fetch (no longer needed for title/summary; still needed for activity logging if `agent_type` is used)
+
+Keep in `handle_stop_hook()`:
+- Step 2: `read_last_exchange()` (for activity logging)
+- Step 6: `append_activity_log()` (Daily/.activity/ JSONL files)
+- The `get_daily_summarizer_session` / `save_daily_summarizer_session` functions move to `session_summarizer.py`
+
+## Implementation Plan
+
+### Phase 1: Extract to `session_summarizer.py`
+
+1. Create `computer/parachute/core/session_summarizer.py`
+2. Move from `activity_hook.py`:
+   - `SUMMARIZER_SYSTEM_PROMPT`
+   - `_should_update_title()` and the `_TITLE_UPDATE_EXCHANGES` / `_TITLE_UPDATE_INTERVAL` constants
+   - `get_daily_summarizer_session()` / `save_daily_summarizer_session()`
+   - Summarizer prompt building logic (currently inline in `call_summarizer()`)
+3. Implement `summarize_session()` as the top-level entry point:
+   - Computes exchange number
+   - Gates on `_should_update_title()`
+   - Fetches session from DB for `title` and `metadata.title_source`
+   - Calls the Claude SDK summarizer
+   - Writes result via `database.update_session()` (with `title_source` guard)
+   - Handles all exceptions — fire-and-forget, never raises
+
+### Phase 2: Wire into Orchestrator
+
+1. Import `summarize_session` in `orchestrator.py`
+2. Add `asyncio.create_task(summarize_session(...))` just before `yield DoneEvent()`
+3. Pass `message`, `result_text`, `tool_calls`, `captured_session_id`, `session`, `self.database`, `self.settings`
+
+### Phase 3: Trim `activity_hook.py`
+
+1. Remove title/summary steps from `handle_stop_hook()`
+2. Remove constants/helpers that moved to `session_summarizer.py`
+3. Keep activity logging intact
+4. Update the docstring/comment to reflect narrowed scope (activity logging only)
+
+### Phase 4: Tests
+
+1. `tests/unit/test_session_summarizer.py` — unit tests for:
+   - `_should_update_title()` cadence (exchanges {1, 3, 5}, every 10th)
+   - `summarize_session()` skips when exchange not in cadence
+   - `summarize_session()` respects `title_source == "user"` guard
+   - `summarize_session()` writes title + summary when appropriate
+   - Exception handling (never raises)
+2. Update `tests/unit/test_activity_hook.py` — remove tests for moved functions
+
+## Acceptance Criteria
+
+- [ ] New chat session: after the 1st AI response, title is generated automatically (within a few seconds, background)
+- [ ] Title is never overwritten when `title_source == "user"` (user-renamed sessions stay renamed)
+- [ ] Works for both direct and sandboxed sessions (orchestrator handles both)
+- [ ] `activity_hook.py` still writes Daily/.activity/ JSONL logs (activity logging unaffected)
+- [ ] No Stop hook configuration needed in vault `.claude/settings.json`
+- [ ] `call_summarizer()` failure is caught silently (never breaks the streaming response)
+- [ ] Exchange cadence preserved: fires at 1, 3, 5, then every 10th
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `computer/parachute/core/session_summarizer.py` | **New** — extracted title/summary logic |
+| `computer/parachute/core/orchestrator.py` | Add `asyncio.create_task(summarize_session(...))` before `yield DoneEvent()` |
+| `computer/parachute/hooks/activity_hook.py` | Remove title/summary steps, keep activity logging |
+| `computer/tests/unit/test_session_summarizer.py` | **New** — unit tests |
+| `computer/tests/unit/test_activity_hook.py` | Remove tests for moved functions |
+
+## References
+
+- `orchestrator.py:1231` — where `result` event is received
+- `orchestrator.py:1299` — `yield DoneEvent(...)` — insertion point for background task
+- `activity_hook.py:73` — `handle_stop_hook()` — source of logic to move/remove
+- `activity_hook.py:158` — `_should_update_title()` — exchange cadence
+- `activity_hook.py:295` — `call_summarizer()` — Claude SDK query to reuse
+- `api/sessions.py:249` — `PATCH /chat/{session_id}/metadata` — write path (or bypass via `database.update_session()`)
+- Issue #121 — PR that added the REST endpoint and MCP tools
+- Issue #119 — PR that added the `summary` column


### PR DESCRIPTION
## Summary

- Moves automatic session title/summary generation from the Stop hook into the orchestrator's streaming event loop
- New `session_summarizer.py` module with extracted title/summary logic, cadence control, and fire-and-forget safety
- Orchestrator fires `asyncio.create_task(summarize_session(...))` just before `yield DoneEvent()` — works uniformly for direct and sandboxed sessions
- `activity_hook.py` trimmed to activity logging only — dead summarizer code removed
- 28 new unit tests covering: cadence (`_should_update`), cache I/O, title guard, exception safety

## Why

The Stop hook approach had two structural problems:
1. **Hook portability**: hook commands embed a host-specific Python path — sandboxed Docker sessions silently fail
2. **Hook registration**: vault `.claude/settings.json` must exist and be kept in sync

The server event loop approach has none of these issues — the orchestrator already handles all sessions.

Closes #122

## Testing

- `pytest tests/unit/test_session_summarizer.py` — 28 tests, all passing
- `pytest tests/unit/test_activity_hook.py` — 8 tests, all passing
- `ruff check` — clean on all modified files

---

Generated with [Claude Code](https://claude.com/claude-code)