### PR TITLE
fix(brain): promote bridge agent logs from DEBUG to INFO

### DIFF
--- a/computer/parachute/core/orchestrator.py
+++ b/computer/parachute/core/orchestrator.py
@@ -1073,9 +1073,11 @@ class Orchestrator:
                     )
                     if _bridge_ctx:
                         effective_prompt = (effective_prompt or "") + "\n\n" + _bridge_ctx
-                        logger.debug(f"Bridge: injected {len(_bridge_ctx)} chars into system prompt")
+                        logger.info(f"Bridge: injected {len(_bridge_ctx)} chars of brain context into system prompt")
+                else:
+                    logger.debug("Bridge: brain not available, skipping enrich")
             except Exception as _bridge_err:
-                logger.debug(f"Bridge enrich error (non-fatal): {_bridge_err}")
+                logger.warning(f"Bridge enrich error (non-fatal): {_bridge_err}")
 
             async for event in query_streaming(
                 prompt=actual_message,


### PR DESCRIPTION
All bridge decision logs were at `logger.debug()` — invisible at the default INFO level. The bridge appeared to not be running when it was actually silently executing on every message.

## Changes
- `bridge_agent.py`: judgment, recall results, injection size, writeback decisions → INFO; failures → WARNING
- `orchestrator.py`: bridge injection confirmation → INFO; errors → WARNING

## After this fix, you'll see logs like:
```
Bridge enrich: judgment=pass_through
Bridge enrich: judgment=enrich
Bridge enrich: query='Woven Web' -> 3 results
Bridge enrich: injecting 842 chars of brain context into system prompt
Bridge writeback: nothing to store for 43355260
Bridge writeback: stored project/'Woven Web'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)