### PR TITLE
feat(daily): parse legacy Obsidian journal files in MCP

### DIFF
--- a/computer/tests/unit/test_mcp_journals.py
+++ b/computer/tests/unit/test_mcp_journals.py
@@ -1,0 +1,241 @@
+"""
+Tests for Daily MCP journal functions.
+
+Covers:
+- _is_legacy_journal(): format detection
+- get_journal(): legacy and new-format parsing
+- list_recent_journals(): legacy and mixed listing
+- search_journals(): legacy and new-format keyword search
+"""
+
+import asyncio
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from parachute.mcp_server import (
+    _is_legacy_journal,
+    get_journal,
+    list_recent_journals,
+    search_journals,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+LEGACY_CONTENT = """\
+Good morning. It's a new day. Typing on Obsidian right now.
+
+Today on the docket: finish the brain module, review PRs, call Kevin about LVB.
+
+Thinking about the Woven Web grant application. Need to send the 990 forms.
+"""
+
+NEW_FORMAT_CONTENT = """\
+---
+date: 2026-01-15
+entries:
+  abc123:
+    type: voice
+---
+
+# para:daily:abc123 07:30
+Had a good session with Claude on the orchestrator refactor.
+
+# para:daily:def456 09:45
+Reviewed the brain module PR. Looking good.
+"""
+
+
+@pytest.fixture
+def journals_dir(tmp_path):
+    """Create a temporary journals directory with test files."""
+    d = tmp_path / "Daily" / "journals"
+    d.mkdir(parents=True)
+
+    # Legacy file
+    (d / "2025-08-01.md").write_text(LEGACY_CONTENT, encoding="utf-8")
+
+    # New-format file
+    (d / "2026-01-15.md").write_text(NEW_FORMAT_CONTENT, encoding="utf-8")
+
+    return d
+
+
+# ---------------------------------------------------------------------------
+# _is_legacy_journal tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsLegacyJournal:
+    def test_legacy_content_detected(self):
+        assert _is_legacy_journal(LEGACY_CONTENT) is True
+
+    def test_new_format_not_legacy(self):
+        assert _is_legacy_journal(NEW_FORMAT_CONTENT) is False
+
+    def test_empty_string_is_legacy(self):
+        assert _is_legacy_journal("") is True
+
+    def test_partial_marker_not_enough(self):
+        assert _is_legacy_journal("Some text with para:daily: but no hash") is True
+
+    def test_exact_marker_not_legacy(self):
+        assert _is_legacy_journal("text\n# para:daily:abc 07:30\ncontent") is False
+
+
+# ---------------------------------------------------------------------------
+# get_journal tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetJournal:
+    @pytest.mark.asyncio
+    async def test_legacy_file_returns_single_entry(self, journals_dir):
+        with patch("parachute.mcp_server._vault_path", str(journals_dir.parent.parent)):
+            result = await get_journal("2025-08-01")
+
+        assert result is not None
+        assert result["date"] == "2025-08-01"
+        assert result["entry_count"] == 1
+        assert len(result["entries"]) == 1
+
+        entry = result["entries"][0]
+        assert entry["id"] == "legacy-2025-08-01"
+        assert entry["time"] is None
+        assert entry["type"] == "legacy"
+        assert "Obsidian" in entry["content"]
+        assert "raw_content" in result
+
+    @pytest.mark.asyncio
+    async def test_new_format_returns_structured_entries(self, journals_dir):
+        with patch("parachute.mcp_server._vault_path", str(journals_dir.parent.parent)):
+            result = await get_journal("2026-01-15")
+
+        assert result is not None
+        assert result["date"] == "2026-01-15"
+        assert result["entry_count"] == 2
+        assert len(result["entries"]) == 2
+
+        first = result["entries"][0]
+        assert first["id"] == "abc123"
+        assert first["time"] == "07:30"
+        assert "type" not in first  # no legacy type on new-format entries
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_none(self, journals_dir):
+        with patch("parachute.mcp_server._vault_path", str(journals_dir.parent.parent)):
+            result = await get_journal("2025-01-01")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# list_recent_journals tests
+# ---------------------------------------------------------------------------
+
+
+class TestListRecentJournals:
+    @pytest.mark.asyncio
+    async def test_lists_both_formats(self, journals_dir):
+        with patch("parachute.mcp_server._vault_path", str(journals_dir.parent.parent)):
+            results = await list_recent_journals(limit=20)
+
+        assert len(results) == 2
+        dates = {r["date"] for r in results}
+        assert "2025-08-01" in dates
+        assert "2026-01-15" in dates
+
+    @pytest.mark.asyncio
+    async def test_legacy_file_has_count_one_and_type(self, journals_dir):
+        with patch("parachute.mcp_server._vault_path", str(journals_dir.parent.parent)):
+            results = await list_recent_journals(limit=20)
+
+        legacy = next(r for r in results if r["date"] == "2025-08-01")
+        assert legacy["entry_count"] == 1
+        assert legacy["type"] == "legacy"
+
+    @pytest.mark.asyncio
+    async def test_new_format_has_correct_count_no_type(self, journals_dir):
+        with patch("parachute.mcp_server._vault_path", str(journals_dir.parent.parent)):
+            results = await list_recent_journals(limit=20)
+
+        new_fmt = next(r for r in results if r["date"] == "2026-01-15")
+        assert new_fmt["entry_count"] == 2
+        assert "type" not in new_fmt
+
+    @pytest.mark.asyncio
+    async def test_limit_respected(self, journals_dir):
+        with patch("parachute.mcp_server._vault_path", str(journals_dir.parent.parent)):
+            results = await list_recent_journals(limit=1)
+
+        # Should only return most recent (2026-01-15)
+        assert len(results) == 1
+        assert results[0]["date"] == "2026-01-15"
+
+    @pytest.mark.asyncio
+    async def test_empty_directory(self, tmp_path):
+        empty_dir = tmp_path / "Daily" / "journals"
+        empty_dir.mkdir(parents=True)
+        with patch("parachute.mcp_server._vault_path", str(tmp_path)):
+            results = await list_recent_journals()
+
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# search_journals tests
+# ---------------------------------------------------------------------------
+
+
+class TestSearchJournals:
+    @pytest.mark.asyncio
+    async def test_finds_match_in_legacy_file(self, journals_dir):
+        with patch("parachute.mcp_server._vault_path", str(journals_dir.parent.parent)):
+            results = await search_journals("Woven Web")
+
+        assert len(results) >= 1
+        legacy_hit = next((r for r in results if r["date"] == "2025-08-01"), None)
+        assert legacy_hit is not None
+        assert legacy_hit["type"] == "legacy"
+        assert legacy_hit["entry_header"] == "legacy:2025-08-01"
+        assert "Woven Web" in legacy_hit["snippet"]
+
+    @pytest.mark.asyncio
+    async def test_finds_match_in_new_format_file(self, journals_dir):
+        with patch("parachute.mcp_server._vault_path", str(journals_dir.parent.parent)):
+            results = await search_journals("orchestrator")
+
+        assert len(results) >= 1
+        hit = next((r for r in results if r["date"] == "2026-01-15"), None)
+        assert hit is not None
+        assert "type" not in hit  # new-format results have no type field
+        assert "orchestrator" in hit["snippet"].lower()
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_empty(self, journals_dir):
+        with patch("parachute.mcp_server._vault_path", str(journals_dir.parent.parent)):
+            results = await search_journals("xyzzy_no_match_here")
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_search(self, journals_dir):
+        with patch("parachute.mcp_server._vault_path", str(journals_dir.parent.parent)):
+            results = await search_journals("woven web")
+
+        legacy_hit = next((r for r in results if r["date"] == "2025-08-01"), None)
+        assert legacy_hit is not None
+
+    @pytest.mark.asyncio
+    async def test_snippet_has_ellipsis_when_truncated(self, journals_dir):
+        with patch("parachute.mcp_server._vault_path", str(journals_dir.parent.parent)):
+            results = await search_journals("grant")
+
+        assert len(results) >= 1
+        snippet = results[0]["snippet"]
+        # Content before match position is > 50 chars, so snippet starts with ...
+        assert snippet.startswith("...")

--- a/docs/plans/2026-02-27-feat-daily-mcp-legacy-journal-parsing-plan.md
+++ b/docs/plans/2026-02-27-feat-daily-mcp-legacy-journal-parsing-plan.md
@@ -1,0 +1,230 @@
+---
+title: "feat(daily): parse legacy Obsidian journal files in MCP"
+type: feat
+date: 2026-02-27
+issue: 127
+---
+
+# feat(daily): parse legacy Obsidian journal files in MCP
+
+## Overview
+
+162 pre-frontmatter journal files (Feb 2025 – Dec 14, 2025) are invisible to the
+Daily MCP. The three Daily MCP functions — `list_recent_journals`, `get_journal`,
+and `search_journals` — assume every file contains `# para:daily:` entry markers.
+Files without those markers return `entry_count: 0` and `entries: []` and are
+therefore completely excluded from Brain's processing pipeline, Daily search, and
+agent reflection.
+
+This plan adds legacy format detection and fallback parsing to those three
+functions. The fix is contained entirely in `computer/parachute/mcp_server.py`.
+
+## Problem Statement
+
+The parser in `get_journal()` (line 1170) splits file content on
+`"\n# para:daily:"` and iterates `parts[1:]`, skipping everything before the
+first marker. For legacy Obsidian files with no such markers, `parts[1:]` is
+empty — the function returns an empty `entries` list despite the file existing
+and `raw_content` being populated.
+
+```python
+# Current (mcp_server.py:1170)
+parts = content.split("\n# para:daily:")
+for i, part in enumerate(parts[1:], 1):   # skips all content on legacy files
+    ...
+```
+
+`list_recent_journals()` (line 1138) counts `"# para:daily:"` occurrences:
+```python
+entry_count = content.count("# para:daily:")   # always 0 for legacy files
+```
+
+`search_journals()` (lines 1082-1083) uses the same split:
+```python
+entries = content.split("\n# para:daily:")
+for i, entry in enumerate(entries[1:], 1):   # skips all content on legacy files
+```
+
+## Proposed Solution
+
+Add a `_is_legacy_journal(content)` helper and update each function with a
+fallback branch for legacy files. No new files, no schema changes — only
+`mcp_server.py` is modified.
+
+### Detection logic
+
+```python
+# mcp_server.py — new helper near line 1040
+def _is_legacy_journal(content: str) -> bool:
+    """True if content lacks para:daily: entry markers (pre-Dec 15 Obsidian format)."""
+    return "# para:daily:" not in content
+```
+
+### `get_journal()` — legacy branch
+
+When `_is_legacy_journal(content)`:
+- Return the full file content as a single entry
+- `id`: `f"legacy-{date}"` (deterministic, stable across reads)
+- `time`: `None`
+- `type`: `"legacy"` (signal to consumers)
+- `entry_count`: `1`
+
+```python
+# mcp_server.py — get_journal() legacy path
+if _is_legacy_journal(content):
+    return {
+        "date": date,
+        "file": str(journal_file.name),
+        "entry_count": 1,
+        "entries": [{
+            "id": f"legacy-{date}",
+            "time": None,
+            "type": "legacy",
+            "content": content,
+        }],
+        "raw_content": content,
+    }
+```
+
+### `list_recent_journals()` — legacy branch
+
+When `_is_legacy_journal(content)`:
+- Report `entry_count: 1` (it is one document)
+- Add `"type": "legacy"` to distinguish from zero-entry new-format files
+
+```python
+# mcp_server.py — list_recent_journals() legacy path
+if _is_legacy_journal(content):
+    results.append({
+        "date": journal_file.stem,
+        "entry_count": 1,
+        "file": str(journal_file.name),
+        "type": "legacy",
+    })
+else:
+    entry_count = content.count("# para:daily:")
+    results.append({
+        "date": journal_file.stem,
+        "entry_count": entry_count,
+        "file": str(journal_file.name),
+    })
+```
+
+### `search_journals()` — legacy branch
+
+When `_is_legacy_journal(content)` and query matches:
+- Treat the entire file as one searchable unit
+- `entry_header`: `f"legacy:{date}"` (placeholder, no structured header)
+- Snippet: same window logic as current code
+
+```python
+# mcp_server.py — search_journals() legacy path
+if _is_legacy_journal(content):
+    if query_lower in content.lower():
+        match_pos = content.lower().find(query_lower)
+        start = max(0, match_pos - 50)
+        end = min(len(content), match_pos + len(query) + 100)
+        snippet = content[start:end]
+        if start > 0:
+            snippet = "..." + snippet
+        if end < len(content):
+            snippet = snippet + "..."
+        results.append({
+            "date": journal_file.stem,
+            "entry_header": f"legacy:{journal_file.stem}",
+            "snippet": snippet,
+            "file": str(journal_file.name),
+            "type": "legacy",
+        })
+else:
+    # existing split-on-para:daily: logic unchanged
+    ...
+```
+
+## Technical Considerations
+
+- **No frontmatter parsing needed.** The existing new-format parser already ignores
+  YAML frontmatter via the `parts[0]` skip. Legacy files have no frontmatter, so
+  returning raw content is the right thing.
+- **`daily_agent_tools.py` is unaffected.** The Daily agent already reads
+  `journal_file.read_text()` as raw text and passes it straight to the agent.
+  Legacy files already work there.
+- **`type: "legacy"` field.** Adding this optional field to responses is backwards
+  compatible — consumers that don't know about it will ignore it. Brain bridge and
+  reflection agents can use it to adjust processing (e.g., skip structured entry
+  extraction and treat as prose).
+- **ID stability.** `f"legacy-{date}"` (e.g. `"legacy-2025-08-01"`) is stable and
+  unique per file. No hash computation needed — date is already the natural key.
+- **No write support.** Legacy files remain read-only. `create_entry()` always
+  writes new-format files to `Daily/entries/`, which is a separate directory.
+
+## Acceptance Criteria
+
+- [ ] `get_journal("2025-08-01")` returns a non-null result with `entry_count: 1`
+  and one entry containing the full file content for a legacy file
+- [ ] `list_recent_journals()` lists legacy journal dates with `entry_count: 1`
+  and `type: "legacy"` in the response
+- [ ] `search_journals(query)` finds matches in legacy file content and returns
+  snippets with `entry_header: "legacy:YYYY-MM-DD"`
+- [ ] New-format files (`# para:daily:` present) are unaffected — behavior identical
+  to before
+- [ ] Unit tests cover: legacy `get_journal`, legacy `list_recent_journals`, legacy
+  `search_journals`, new-format files unaffected
+- [ ] No other files are modified
+
+## Implementation
+
+All changes are in `computer/parachute/mcp_server.py`.
+
+### Step 1 — Add helper near line 1040
+
+```python
+# computer/parachute/mcp_server.py
+def _is_legacy_journal(content: str) -> bool:
+    """Return True if content lacks para:daily: markers (pre-Dec 15, 2025 Obsidian format)."""
+    return "# para:daily:" not in content
+```
+
+### Step 2 — Update `search_journals()` (~line 1076)
+
+Wrap the existing `entries = content.split(...)` block in an `else` branch.
+Add a legacy branch before it that searches the whole file.
+
+### Step 3 — Update `list_recent_journals()` (~line 1136)
+
+Replace the `entry_count = content.count(...)` line with a conditional.
+
+### Step 4 — Update `get_journal()` (~line 1165)
+
+Add early-return legacy branch after reading `content` and before the `parts = content.split(...)` call.
+
+### Step 5 — Add unit tests
+
+New file: `computer/tests/unit/test_mcp_journals.py`
+
+```python
+# computer/tests/unit/test_mcp_journals.py
+import pytest
+from parachute.mcp_server import (
+    _is_legacy_journal,
+    get_journal,
+    list_recent_journals,
+    search_journals,
+)
+
+# Tests for _is_legacy_journal
+# Tests for get_journal with legacy file
+# Tests for get_journal with new-format file
+# Tests for list_recent_journals with mixed files
+# Tests for search_journals with legacy match
+# Tests for search_journals with no legacy match
+```
+
+## References
+
+- **Daily MCP functions**: `computer/parachute/mcp_server.py:1040-1198`
+- **Tool schemas**: `computer/parachute/mcp_server.py:326-380`
+- **Tool dispatch**: `computer/parachute/mcp_server.py:1278-1292`
+- **Daily agent (unaffected)**: `computer/parachute/core/daily_agent.py`
+- **Existing MCP tests**: `computer/tests/unit/test_mcp_session_metadata.py`
+- **GitHub issue**: #127


### PR DESCRIPTION
## Summary

- **162 legacy journal files** (Feb–Dec 2025, plain Obsidian markdown) were invisible to the Daily MCP because the parser expected `# para:daily:` entry markers that don't exist in these files
- Adds `_is_legacy_journal(content)` helper to detect the format and fallback branches in all three Daily MCP functions
- Zero behavior change for new-format files

## Changes

**`computer/parachute/mcp_server.py`** — all changes confined here:
- `_is_legacy_journal()`: returns `True` if `"# para:daily:"` is absent from content
- `get_journal()`: returns whole file as a single entry with `id=legacy-{date}`, `type=legacy` for legacy files
- `list_recent_journals()`: reports `entry_count=1`, `type=legacy` for legacy files instead of 0
- `search_journals()`: searches full file as one unit, `entry_header=legacy:{date}`

**`computer/tests/unit/test_mcp_journals.py`** — 18 new unit tests covering all functions in both formats.

## Testing

- 18 new tests, all passing
- No regressions (baseline: 33 pre-existing failures unchanged)

Closes #127

---

Generated with [Claude Code](https://claude.com/claude-code)