### PR TITLE
feat(computer): add setting_sources=[project] to sandboxed session entrypoint

### DIFF
--- a/computer/parachute/docker/entrypoint.py
+++ b/computer/parachute/docker/entrypoint.py
@@ -225,13 +225,15 @@ async def run():
         # Use the resolved CWD (either PARACHUTE_CWD or process default)
         effective_cwd = os.getcwd()
 
-        # Note: No setting_sources — Parachute explicitly constructs all parameters.
-        # The host passes system prompt, capabilities, model, etc. via mounted files
-        # and environment variables. No SDK auto-discovery.
+        # setting_sources=["project"] enables CWD-aware discovery of .claude/ settings
+        # (commands, custom agents, hooks) walking up from the working directory.
+        # Consistent with direct sessions. Scoped to mounted paths only — the vault
+        # is not fully mounted in sandboxed sessions, so no vault-wide leakage.
         options_kwargs: dict = {
             "permission_mode": "bypassPermissions",
             "env": {"CLAUDE_CODE_OAUTH_TOKEN": oauth_token},
             "cwd": effective_cwd,
+            "setting_sources": ["project"],
         }
 
         # System prompt: prefer stdin payload (persistent mode),


### PR DESCRIPTION
## Summary

Adds `setting_sources=["project"]` to `ClaudeAgentOptions` in the sandbox entrypoint, enabling CWD-aware discovery of `.claude/` settings for sandboxed sessions.

Previously sandboxed sessions explicitly opted out of SDK auto-discovery. This meant project-level commands, custom agents, and hooks were invisible to sandbox agents even when the project directory was mounted. Direct sessions already use `setting_sources=["project"]` — this closes the gap.

**Safety**: sandbox sessions only mount specific allowed paths (not the full vault), so discovery is scoped to what's actually accessible in the container.

Closes #123

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>