### PR TITLE
fix(tests): update unit tests for TrustLevel rename and model drift

### DIFF
--- a/computer/tests/unit/test_skills.py
+++ b/computer/tests/unit/test_skills.py
@@ -458,9 +458,11 @@ Content.
 
         prompt_section = get_skills_for_system_prompt(tmp_path)
 
-        assert "## Available Skills" in prompt_section
-        assert "**Alpha**: Does alpha things" in prompt_section
-        assert "**Beta**: Does beta things" in prompt_section
+        assert "<vault_skills>" in prompt_section
+        assert 'name="Alpha"' in prompt_section
+        assert "Does alpha things" in prompt_section
+        assert 'name="Beta"' in prompt_section
+        assert "Does beta things" in prompt_section
 
     def test_returns_empty_when_no_skills(self, tmp_path):
         """Test returns empty string when no skills."""

--- a/computer/tests/unit/test_workspaces.py
+++ b/computer/tests/unit/test_workspaces.py
@@ -59,12 +59,12 @@ class TestWorkspaceCRUD:
     """Tests for workspace CRUD operations."""
 
     def test_create_workspace(self, vault_path):
-        create = WorkspaceCreate(name="Coding", trust_level="full")
+        create = WorkspaceCreate(name="Coding", default_trust_level="direct")
         workspace = create_workspace(vault_path, create)
 
         assert workspace.name == "Coding"
         assert workspace.slug == "coding"
-        assert workspace.trust_level == "full"
+        assert workspace.default_trust_level == "direct"
 
         # Verify file was created
         config_file = vault_path / ".parachute/workspaces/coding/config.yaml"
@@ -106,11 +106,11 @@ class TestWorkspaceCRUD:
         create_workspace(vault_path, WorkspaceCreate(name="Test"))
         updated = update_workspace(
             vault_path, "test",
-            WorkspaceUpdate(description="Updated", trust_level="vault"),
+            WorkspaceUpdate(description="Updated", default_trust_level="sandboxed"),
         )
         assert updated is not None
         assert updated.description == "Updated"
-        assert updated.trust_level == "vault"
+        assert updated.default_trust_level == "sandboxed"
         assert updated.name == "Test"  # unchanged
         assert updated.slug == "test"  # cannot change
 
@@ -150,11 +150,11 @@ class TestWorkspaceCRUD:
         assert loaded.model == "opus"
 
     def test_workspace_to_api_dict(self, vault_path):
-        create = WorkspaceCreate(name="Test", trust_level="vault")
+        create = WorkspaceCreate(name="Test", default_trust_level="sandboxed")
         workspace = create_workspace(vault_path, create)
         api_dict = workspace.to_api_dict()
 
         assert api_dict["name"] == "Test"
         assert api_dict["slug"] == "test"
-        assert api_dict["trust_level"] == "vault"
+        assert api_dict["default_trust_level"] == "sandboxed"
         assert "capabilities" in api_dict


### PR DESCRIPTION
## Summary

- **Production fix**: `mcp_server.create_session()` was calling `SessionManager.init_session()` which no longer exists. Removed the dead call — session creation returns success after the DB record is written.
- **33 test failures fixed** across 6 test files, all caused by drift from the TrustLevel binary-model refactor and container-per-chat work.

## Root causes fixed

| File | Issue | Fix |
|------|-------|-----|
| `mcp_server.py` | `init_session()` no longer exists on `SessionManager` | Remove dead call |
| `test_trust_levels.py` | References `TrustLevel.FULL/VAULT`, `trust_mode` param, `effective_trust_level` | Update to `DIRECT/SANDBOXED`, remove `trust_mode` |
| `test_permissions.py` | `SessionPermissions(trust_mode=False)` silently ignored → DIRECT behavior | Use `trustLevel=TrustLevel.SANDBOXED` for restricted sessions |
| `test_capability_filter.py` | `PluginConfig(include_user=False)` deprecated; "vault"/"full" session trust not in `TRUST_ORDER` | Use plugin slug list; use "direct"/"sandboxed" |
| `test_workspaces.py` | Used `trust_level=` instead of `default_trust_level=`; "vault"/"full" values | Use correct field names and canonical values |
| `test_mcp_multi_agent.py` | `send_message` returns `validation_passed` not `success`; spawn test hit rate limiter | Update assertion; mock `get_last_child_created` |
| `test_skills.py` | System prompt format changed from `## Available Skills` to `<vault_skills>` XML | Update assertion |

## Result

489 passed, 4 skipped (integration tests requiring pre-created vault), 0 failures.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)