### PR TITLE
feat(computer): container file browser API + remove scratch volumes

### DIFF
--- a/computer/parachute/api/__init__.py
+++ b/computer/parachute/api/__init__.py
@@ -5,9 +5,9 @@ API routes for Parachute server.
 from fastapi import APIRouter
 
 from parachute.api import (
-    agents, auth, bots, capabilities, chat, claude_code, containers, context_folders,
-    filesystem, health, hooks, imports, mcp, models, modules, plugins, prompts,
-    sandbox, scheduler, sessions, settings, skills, sync, usage,
+    agents, auth, bots, capabilities, chat, claude_code, container_files, containers,
+    context_folders, filesystem, health, hooks, imports, mcp, models, modules, plugins,
+    prompts, sandbox, scheduler, sessions, settings, skills, sync, usage,
 )
 
 # Create main API router
@@ -34,6 +34,7 @@ api_router.include_router(hooks.router, tags=["hooks"])
 api_router.include_router(bots.router, tags=["bots"])
 api_router.include_router(sandbox.router, tags=["sandbox"])
 api_router.include_router(containers.router, tags=["containers"])
+api_router.include_router(container_files.router, tags=["container-files"])
 api_router.include_router(agents.router, tags=["agents"])
 api_router.include_router(capabilities.router, tags=["capabilities"])
 api_router.include_router(plugins.router, tags=["plugins"])

--- a/computer/parachute/api/container_files.py
+++ b/computer/parachute/api/container_files.py
@@ -1,0 +1,249 @@
+"""
+Container file browser API endpoints.
+
+Provides file system navigation for container env home directories:
+listing, downloading, uploading, creating directories, and deleting files.
+"""
+
+import asyncio
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Query, Request, UploadFile
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+from parachute.config import get_settings
+from parachute.core.sandbox import SANDBOX_DATA_DIR
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/containers", tags=["container-files"])
+
+# 50 MB upload limit
+MAX_UPLOAD_SIZE = 50 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class FileEntry(BaseModel):
+    name: str
+    path: str
+    type: str  # "file" or "directory"
+    size: int | None = None
+    lastModified: str | None = None
+    isDirectory: bool
+    isFile: bool
+
+
+class DirectoryListing(BaseModel):
+    slug: str
+    path: str
+    entries: list[FileEntry]
+
+
+class FileOperationResult(BaseModel):
+    success: bool
+    path: str
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_home_dir(slug: str) -> Path:
+    """Return the host-side home directory for a container env."""
+    settings = get_settings()
+    return settings.parachute_dir / SANDBOX_DATA_DIR / "envs" / slug / "home"
+
+
+async def _validate_slug(request: Request, slug: str) -> Path:
+    """Validate that the container env exists in the DB. Returns its home dir."""
+    db = request.app.state.session_store
+    env = await db.get_container_env(slug)
+    if not env:
+        raise HTTPException(status_code=404, detail=f"Container env '{slug}' not found")
+    return _get_home_dir(slug)
+
+
+def _resolve_safe_path(home_dir: Path, relative_path: str) -> Path:
+    """Resolve a relative path within home_dir, preventing traversal."""
+    # Strip leading slashes so it's always relative
+    cleaned = relative_path.lstrip("/")
+    target = (home_dir / cleaned).resolve()
+    home_resolved = home_dir.resolve()
+    if not target.is_relative_to(home_resolved):
+        raise HTTPException(status_code=403, detail="Access denied: path outside container home")
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{slug}/files", response_model=DirectoryListing)
+async def list_files(
+    request: Request,
+    slug: str,
+    path: str | None = Query(None, description="Relative path within container home"),
+    includeHidden: bool = Query(False, description="Include hidden files/folders"),
+):
+    """List directory contents in a container env's home directory."""
+    home_dir = await _validate_slug(request, slug)
+
+    if path:
+        target = _resolve_safe_path(home_dir, path)
+    else:
+        target = home_dir
+
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="Path not found")
+    if not target.is_dir():
+        raise HTTPException(status_code=400, detail="Path is not a directory")
+
+    entries: list[FileEntry] = []
+    try:
+        for item in sorted(target.iterdir()):
+            if item.name.startswith(".") and not includeHidden:
+                continue
+
+            try:
+                stat = item.stat()
+            except (OSError, FileNotFoundError):
+                continue
+
+            is_dir = item.is_dir()
+            entries.append(FileEntry(
+                name=item.name,
+                path=str(item.relative_to(home_dir)),
+                type="directory" if is_dir else "file",
+                size=stat.st_size if not is_dir else None,
+                lastModified=datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+                isDirectory=is_dir,
+                isFile=item.is_file(),
+            ))
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Permission denied")
+
+    rel_path = str(target.relative_to(home_dir)) if target != home_dir else ""
+    return DirectoryListing(slug=slug, path=rel_path, entries=entries)
+
+
+@router.get("/{slug}/files/download")
+async def download_file(
+    request: Request,
+    slug: str,
+    path: str = Query(..., description="Relative path to file within container home"),
+):
+    """Download a file from a container env's home directory."""
+    home_dir = await _validate_slug(request, slug)
+    target = _resolve_safe_path(home_dir, path)
+
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="File not found")
+    if not target.is_file():
+        raise HTTPException(status_code=400, detail="Path is not a file")
+
+    return FileResponse(
+        path=str(target),
+        filename=target.name,
+        media_type="application/octet-stream",
+    )
+
+
+@router.post("/{slug}/files/upload", response_model=list[FileOperationResult])
+async def upload_files(
+    request: Request,
+    slug: str,
+    files: list[UploadFile],
+    path: str | None = Query(None, description="Relative directory to upload into"),
+):
+    """Upload file(s) to a container env's home directory (50MB limit per file)."""
+    home_dir = await _validate_slug(request, slug)
+
+    if path:
+        upload_dir = _resolve_safe_path(home_dir, path)
+    else:
+        upload_dir = home_dir
+
+    upload_dir.mkdir(parents=True, exist_ok=True)
+
+    results: list[FileOperationResult] = []
+    for file in files:
+        content = await file.read()
+        if len(content) > MAX_UPLOAD_SIZE:
+            results.append(FileOperationResult(
+                success=False,
+                path=file.filename or "",
+                message=f"File exceeds {MAX_UPLOAD_SIZE // (1024 * 1024)}MB limit",
+            ))
+            continue
+
+        safe_name = Path(file.filename or "unnamed").name
+        dest = upload_dir / safe_name
+        try:
+            await asyncio.to_thread(dest.write_bytes, content)
+            rel = str(dest.relative_to(home_dir))
+            results.append(FileOperationResult(success=True, path=rel, message="Uploaded"))
+        except Exception as e:
+            results.append(FileOperationResult(
+                success=False,
+                path=file.filename or "",
+                message=str(e),
+            ))
+
+    return results
+
+
+@router.post("/{slug}/files/mkdir", response_model=FileOperationResult)
+async def make_directory(
+    request: Request,
+    slug: str,
+    path: str = Query(..., description="Relative path for the new directory"),
+):
+    """Create a directory in a container env's home directory."""
+    home_dir = await _validate_slug(request, slug)
+    target = _resolve_safe_path(home_dir, path)
+
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+        rel = str(target.relative_to(home_dir))
+        return FileOperationResult(success=True, path=rel, message="Directory created")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete("/{slug}/files", response_model=FileOperationResult)
+async def delete_file(
+    request: Request,
+    slug: str,
+    path: str = Query(..., description="Relative path to delete"),
+):
+    """Delete a file or directory from a container env's home directory."""
+    home_dir = await _validate_slug(request, slug)
+    target = _resolve_safe_path(home_dir, path)
+
+    # Cannot delete the home dir itself
+    if target.resolve() == home_dir.resolve():
+        raise HTTPException(status_code=400, detail="Cannot delete the home directory itself")
+
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="Path not found")
+
+    try:
+        if target.is_dir():
+            await asyncio.to_thread(shutil.rmtree, target)
+        else:
+            target.unlink()
+        rel = str(target.relative_to(home_dir))
+        return FileOperationResult(success=True, path=rel, message="Deleted")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/computer/parachute/core/sandbox.py
+++ b/computer/parachute/core/sandbox.py
@@ -47,8 +47,6 @@ SANDBOX_IMAGE = "parachute-sandbox:latest"
 # Shared read-only tools volume — mounted at /opt/parachute-tools in all containers
 TOOLS_VOLUME_NAME = "parachute-tools"
 
-# Per-env persistent scratch volume prefix — mounted at /scratch in named env containers
-SCRATCH_VOLUME_PREFIX = "parachute-scratch"
 
 # Container resource limits — intentionally relaxed for a single-user local tool.
 # OrbStack manages the VM memory budget; these are just runaway-process guardrails.
@@ -560,7 +558,6 @@ class DockerSandbox:
 
         Container: parachute-env-<slug>
         Home dir: vault/.parachute/sandbox/envs/<slug>/home/ → /home/sandbox/
-        Scratch: parachute-scratch-<slug> volume → /scratch (persistent across restarts)
         Creates if absent, starts if stopped. Idempotent.
         """
         container_name = f"parachute-env-{slug}"
@@ -571,7 +568,6 @@ class DockerSandbox:
             "env_slug": slug,
             "config_hash": self._calculate_config_hash(),
         }
-        await self._ensure_scratch_volume(slug)
         return await self._ensure_container(container_name, slug, home_dir, labels, config)
 
     async def run_session(
@@ -603,7 +599,7 @@ class DockerSandbox:
             yield event
 
     async def delete_container(self, slug: str) -> None:
-        """Stop and remove a container env, its vault home directory, and scratch volume."""
+        """Stop and remove a container env and its vault home directory."""
         container_name = f"parachute-env-{slug}"
         await self._stop_container(container_name)
         await self._remove_container(container_name)
@@ -612,7 +608,6 @@ class DockerSandbox:
         if home_dir.exists():
             await asyncio.to_thread(shutil.rmtree, home_dir, True)
             logger.info(f"Removed home dir for container env {slug}")
-        await self._remove_scratch_volume(slug)
 
     async def stop_all_env_containers(self) -> None:
         """Stop all running parachute-env-* containers.
@@ -673,7 +668,7 @@ class DockerSandbox:
 
         Args:
             container_name: Name for the container
-            slug: Container env slug (used to name the scratch volume)
+            slug: Container env slug
             config: Sandbox configuration
             labels: Docker labels for discovery
             home_dir: Host directory bind-mounted to /home/sandbox/ for portability.
@@ -722,12 +717,6 @@ class DockerSandbox:
 
         # Vault mounts (nested inside /home/sandbox/Parachute/ — read-only overlay)
         args.extend(vault_mounts)
-
-        # Persistent scratch volume — survives container restarts
-        args.extend([
-            "--mount",
-            f"source={SCRATCH_VOLUME_PREFIX}-{slug},target=/scratch",
-        ])
 
         # Shared tools volume (read-only) — bin/ in PATH, python/ in PYTHONPATH
         args.extend([
@@ -933,36 +922,6 @@ class DockerSandbox:
         await proc.wait()
         # returncode 0 = created, may also succeed if already exists
 
-    async def _ensure_scratch_volume(self, slug: str) -> None:
-        """Create a persistent scratch volume for a container env if it doesn't exist.
-
-        Named volume parachute-scratch-<slug> is mounted at /scratch inside the
-        container, replacing the ephemeral tmpfs. Files survive container restarts.
-        """
-        vol = f"{SCRATCH_VOLUME_PREFIX}-{slug}"
-        proc = await asyncio.create_subprocess_exec(
-            "docker", "volume", "create",
-            "--label", "app=parachute",
-            "--label", "type=scratch",
-            "--label", f"slug={slug}",
-            vol,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        await proc.wait()
-
-    async def _remove_scratch_volume(self, slug: str) -> None:
-        """Remove the persistent scratch volume for a container env."""
-        vol = f"{SCRATCH_VOLUME_PREFIX}-{slug}"
-        proc = await asyncio.create_subprocess_exec(
-            "docker", "volume", "rm", vol,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        await proc.wait()
-        if proc.returncode != 0:
-            logger.debug(f"docker volume rm {vol} exited {proc.returncode} — may not exist or already removed")
-
     async def reconcile(self, active_slugs: set[str] | None = None) -> None:
         """Reconcile parachute containers on server startup.
 
@@ -1039,42 +998,3 @@ class DockerSandbox:
 
         if active_env_names:
             logger.info(f"Active env containers: {', '.join(active_env_names)}")
-
-        # Clean up orphaned scratch volumes
-        if active_slugs is not None:
-            await self._reconcile_scratch_volumes(active_slugs)
-
-    async def _reconcile_scratch_volumes(self, active_slugs: set[str]) -> None:
-        """Remove scratch volumes for container envs that no longer exist in the DB."""
-        proc = await asyncio.create_subprocess_exec(
-            "docker", "volume", "ls",
-            "--filter", "label=type=scratch",
-            "--format", "{{.Name}}",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        stdout, _ = await proc.communicate()
-        if proc.returncode != 0:
-            return
-
-        orphan_slugs = []
-        for line in stdout.decode().strip().split("\n"):
-            vol = line.strip()
-            if not vol.startswith(f"{SCRATCH_VOLUME_PREFIX}-"):
-                continue
-            slug = vol[len(f"{SCRATCH_VOLUME_PREFIX}-"):]
-            if slug not in active_slugs:
-                orphan_slugs.append(slug)
-
-        if orphan_slugs:
-            results = await asyncio.gather(*[
-                self._remove_scratch_volume(slug)
-                for slug in orphan_slugs
-            ], return_exceptions=True)
-            orphan_vols = [f"{SCRATCH_VOLUME_PREFIX}-{s}" for s in orphan_slugs]
-            for vol, result in zip(orphan_vols, results):
-                if isinstance(result, Exception):
-                    logger.warning(f"Failed to remove orphaned scratch volume {vol}: {result}")
-            removed = sum(1 for r in results if not isinstance(r, Exception))
-            if removed:
-                logger.info(f"Removed {removed}/{len(orphan_slugs)} orphaned scratch volume(s): {', '.join(orphan_vols)}")

--- a/computer/parachute/docker/Dockerfile.sandbox
+++ b/computer/parachute/docker/Dockerfile.sandbox
@@ -73,11 +73,6 @@ RUN useradd -m -u 1000 -s /bin/bash sandbox
 # Set ownership so sandbox user can read tools when mounted
 RUN chown -R sandbox:sandbox /opt/parachute-tools
 
-# Create /scratch with sandbox ownership — Docker named volumes initialize
-# from this directory's permissions on first mount, so new scratch volumes
-# will be writable by the sandbox user without a separate chown step.
-RUN mkdir -p /scratch && chown sandbox:sandbox /scratch
-
 # Health check (verify Python is functional)
 HEALTHCHECK --interval=60s --timeout=10s --retries=2 \
     CMD python -c "print('ok')" || exit 1

--- a/computer/tests/unit/test_container_files.py
+++ b/computer/tests/unit/test_container_files.py
@@ -1,0 +1,308 @@
+"""
+Tests for container file browser API helpers and endpoints.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from parachute.api.container_files import (
+    _get_home_dir,
+    _resolve_safe_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_safe_path tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSafePath:
+    def test_normal_path(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "subdir").mkdir()
+        result = _resolve_safe_path(home, "subdir")
+        assert result == (home / "subdir").resolve()
+
+    def test_leading_slash_stripped(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "file.txt").touch()
+        result = _resolve_safe_path(home, "/file.txt")
+        assert result == (home / "file.txt").resolve()
+
+    def test_traversal_blocked(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        with pytest.raises(HTTPException) as exc_info:
+            _resolve_safe_path(home, "../etc/passwd")
+        assert exc_info.value.status_code == 403
+
+    def test_double_dot_in_middle_blocked(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "subdir").mkdir()
+        with pytest.raises(HTTPException) as exc_info:
+            _resolve_safe_path(home, "subdir/../../etc/passwd")
+        assert exc_info.value.status_code == 403
+
+    def test_sibling_dir_prefix_blocked(self, tmp_path):
+        """Regression: 'homeevil' must not pass check when home is 'home'."""
+        home = tmp_path / "home"
+        home.mkdir()
+        (tmp_path / "homeevil").mkdir()
+        (tmp_path / "homeevil" / "secret.txt").touch()
+        with pytest.raises(HTTPException) as exc_info:
+            _resolve_safe_path(home, "../homeevil/secret.txt")
+        assert exc_info.value.status_code == 403
+
+    def test_empty_path(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        result = _resolve_safe_path(home, "")
+        assert result == home.resolve()
+
+
+# ---------------------------------------------------------------------------
+# _get_home_dir tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetHomeDir:
+    def test_correct_path(self):
+        with patch("parachute.api.container_files.get_settings") as mock_settings:
+            mock_settings.return_value.parachute_dir = Path("/fake/.parachute")
+            result = _get_home_dir("my-env")
+            assert result == Path("/fake/.parachute/sandbox/envs/my-env/home")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (using tmp dirs, no Docker)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def home_dir(tmp_path):
+    """Create a temporary container home directory with some files."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "file.txt").write_text("hello world")
+    (home / "subdir").mkdir()
+    (home / "subdir" / "nested.txt").write_text("nested content")
+    (home / ".hidden").write_text("secret")
+    return home
+
+
+@pytest.fixture
+def mock_app(home_dir):
+    """Create a mock FastAPI app with session store that returns a container env."""
+    app = MagicMock()
+    mock_env = MagicMock()
+    mock_env.slug = "test-env"
+
+    store = AsyncMock()
+    store.get_container_env = AsyncMock(return_value=mock_env)
+    app.state.session_store = store
+    return app
+
+
+@pytest.fixture
+def mock_request(mock_app):
+    """Create a mock request with app state."""
+    request = MagicMock()
+    request.app = mock_app
+    return request
+
+
+class TestListFiles:
+    @pytest.mark.asyncio
+    async def test_list_root(self, mock_request, home_dir):
+        from parachute.api.container_files import list_files
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            result = await list_files(mock_request, "test-env", path=None, includeHidden=False)
+
+        assert result.slug == "test-env"
+        assert result.path == ""
+        names = [e.name for e in result.entries]
+        assert "file.txt" in names
+        assert "subdir" in names
+        assert ".hidden" not in names
+
+    @pytest.mark.asyncio
+    async def test_list_with_hidden(self, mock_request, home_dir):
+        from parachute.api.container_files import list_files
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            result = await list_files(mock_request, "test-env", path=None, includeHidden=True)
+
+        names = [e.name for e in result.entries]
+        assert ".hidden" in names
+
+    @pytest.mark.asyncio
+    async def test_list_subdir(self, mock_request, home_dir):
+        from parachute.api.container_files import list_files
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            result = await list_files(mock_request, "test-env", path="subdir", includeHidden=False)
+
+        assert result.path == "subdir"
+        names = [e.name for e in result.entries]
+        assert "nested.txt" in names
+
+    @pytest.mark.asyncio
+    async def test_list_nonexistent(self, mock_request, home_dir):
+        from parachute.api.container_files import list_files
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            with pytest.raises(HTTPException) as exc_info:
+                await list_files(mock_request, "test-env", path="nope", includeHidden=False)
+            assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_slug_not_found(self, mock_request, home_dir):
+        from parachute.api.container_files import list_files
+
+        mock_request.app.state.session_store.get_container_env = AsyncMock(return_value=None)
+        with pytest.raises(HTTPException) as exc_info:
+            await list_files(mock_request, "bad-slug", path=None, includeHidden=False)
+        assert exc_info.value.status_code == 404
+
+
+class TestDownloadFile:
+    @pytest.mark.asyncio
+    async def test_download(self, mock_request, home_dir):
+        from parachute.api.container_files import download_file
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            response = await download_file(mock_request, "test-env", path="file.txt")
+
+        assert response.filename == "file.txt"
+
+    @pytest.mark.asyncio
+    async def test_download_not_found(self, mock_request, home_dir):
+        from parachute.api.container_files import download_file
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            with pytest.raises(HTTPException) as exc_info:
+                await download_file(mock_request, "test-env", path="nope.txt")
+            assert exc_info.value.status_code == 404
+
+
+class TestMakeDirectory:
+    @pytest.mark.asyncio
+    async def test_mkdir(self, mock_request, home_dir):
+        from parachute.api.container_files import make_directory
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            result = await make_directory(mock_request, "test-env", path="newdir/nested")
+
+        assert result.success is True
+        assert (home_dir / "newdir" / "nested").is_dir()
+
+
+class TestDeleteFile:
+    @pytest.mark.asyncio
+    async def test_delete_file(self, mock_request, home_dir):
+        from parachute.api.container_files import delete_file
+
+        assert (home_dir / "file.txt").exists()
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            result = await delete_file(mock_request, "test-env", path="file.txt")
+
+        assert result.success is True
+        assert not (home_dir / "file.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_delete_directory(self, mock_request, home_dir):
+        from parachute.api.container_files import delete_file
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            result = await delete_file(mock_request, "test-env", path="subdir")
+
+        assert result.success is True
+        assert not (home_dir / "subdir").exists()
+
+    @pytest.mark.asyncio
+    async def test_delete_home_blocked(self, mock_request, home_dir):
+        from parachute.api.container_files import delete_file
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_file(mock_request, "test-env", path="")
+            assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_delete_not_found(self, mock_request, home_dir):
+        from parachute.api.container_files import delete_file
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_file(mock_request, "test-env", path="nope")
+            assert exc_info.value.status_code == 404
+
+
+class TestUploadFiles:
+    @pytest.mark.asyncio
+    async def test_upload(self, mock_request, home_dir):
+        from parachute.api.container_files import upload_files
+
+        mock_file = MagicMock(spec=["read", "filename"])
+        mock_file.filename = "uploaded.txt"
+        mock_file.read = AsyncMock(return_value=b"file content")
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            results = await upload_files(mock_request, "test-env", files=[mock_file], path=None)
+
+        assert len(results) == 1
+        assert results[0].success is True
+        assert (home_dir / "uploaded.txt").read_bytes() == b"file content"
+
+    @pytest.mark.asyncio
+    async def test_upload_too_large(self, mock_request, home_dir):
+        from parachute.api.container_files import upload_files, MAX_UPLOAD_SIZE
+
+        mock_file = MagicMock(spec=["read", "filename"])
+        mock_file.filename = "big.bin"
+        mock_file.read = AsyncMock(return_value=b"x" * (MAX_UPLOAD_SIZE + 1))
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            results = await upload_files(mock_request, "test-env", files=[mock_file], path=None)
+
+        assert len(results) == 1
+        assert results[0].success is False
+        assert "limit" in results[0].message
+
+    @pytest.mark.asyncio
+    async def test_upload_to_subdir(self, mock_request, home_dir):
+        from parachute.api.container_files import upload_files
+
+        mock_file = MagicMock(spec=["read", "filename"])
+        mock_file.filename = "data.csv"
+        mock_file.read = AsyncMock(return_value=b"a,b,c")
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            results = await upload_files(mock_request, "test-env", files=[mock_file], path="uploads/2024")
+
+        assert results[0].success is True
+        assert (home_dir / "uploads" / "2024" / "data.csv").read_bytes() == b"a,b,c"
+
+    @pytest.mark.asyncio
+    async def test_upload_traversal_filename_stripped(self, mock_request, home_dir):
+        """Regression: malicious filename with ../ must be stripped to basename."""
+        from parachute.api.container_files import upload_files
+
+        mock_file = MagicMock(spec=["read", "filename"])
+        mock_file.filename = "../../etc/evil.txt"
+        mock_file.read = AsyncMock(return_value=b"payload")
+
+        with patch("parachute.api.container_files._get_home_dir", return_value=home_dir):
+            results = await upload_files(mock_request, "test-env", files=[mock_file], path=None)
+
+        assert results[0].success is True
+        # File should be written as "evil.txt" in home dir, not outside it
+        assert (home_dir / "evil.txt").read_bytes() == b"payload"
+        assert not (home_dir.parent.parent / "etc" / "evil.txt").exists()

--- a/computer/tests/unit/test_trust_levels.py
+++ b/computer/tests/unit/test_trust_levels.py
@@ -23,6 +23,7 @@ from parachute.core.sandbox import (
     SANDBOX_IMAGE,
     CONTAINER_MEMORY_LIMIT_EPHEMERAL,
     CONTAINER_CPU_LIMIT,
+    TOOLS_VOLUME_NAME,
 )
 from parachute.core.module_loader import (
     compute_module_hash,
@@ -254,7 +255,6 @@ class TestDockerSandbox:
         assert container_name == "parachute-env-my-project"
 
     def test_persistent_container_args_has_tools_volume(self, vault_path):
-        from parachute.core.sandbox import TOOLS_VOLUME_NAME, SCRATCH_VOLUME_PREFIX
         sandbox = DockerSandbox(parachute_dir=vault_path)
         config = AgentSandboxConfig(session_id="test123")
         labels = {"app": "parachute", "type": "env"}
@@ -267,9 +267,6 @@ class TestDockerSandbox:
         assert TOOLS_VOLUME_NAME in arg_str
         assert "/opt/parachute-tools" in arg_str
         assert "readonly" in arg_str
-        # Scratch volume is mounted at /scratch (persistent named volume)
-        assert f"{SCRATCH_VOLUME_PREFIX}-test123" in arg_str
-        assert "/scratch" in arg_str
 
     def test_persistent_container_args_mounts_home_dir(self, vault_path):
         """All containers bind-mount the parachute home dir to /home/sandbox/."""


### PR DESCRIPTION
## Summary

- **Remove scratch volume machinery** — `SCRATCH_VOLUME_PREFIX`, `_ensure_scratch_volume()`, `_remove_scratch_volume()`, `_reconcile_scratch_volumes()`, Dockerfile `/scratch` mkdir, and all call sites. The agent never uses `/scratch` since entrypoint defaults CWD to the bind-mounted home dir.
- **Add container file browser API** — 5 REST endpoints at `/api/containers/{slug}/files` for listing, downloading, uploading (50MB limit), creating directories, and deleting files in a container env's host-side home directory. Includes path traversal prevention via `Path.is_relative_to()` and filename sanitization on uploads.

## Test plan

- [x] `pytest tests/unit/test_trust_levels.py` — scratch assertions removed, all 46 pass
- [x] `pytest tests/unit/test_container_files.py` — 23 tests covering helpers + all endpoints
- [x] `pytest tests/unit/ --ignore=tests/unit/test_daily_module.py` — full suite 480 pass
- [ ] Manual: `curl localhost:3333/api/containers/<slug>/files` lists home dir
- [ ] Manual: upload/download a file via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)