### PR TITLE
chore(app): remove dead VaultSettingsSection constructor params

### DIFF
--- a/app/lib/features/settings/screens/settings_screen.dart
+++ b/app/lib/features/settings/screens/settings_screen.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/providers/app_state_provider.dart'
     show AppMode, appModeProvider, isDailyOnlyFlavor, isComputerFlavor;
-import 'package:parachute/core/providers/file_system_provider.dart';
 import 'package:parachute/core/providers/server_providers.dart' show isBundledAppProvider;
 import 'package:parachute/core/providers/bare_metal_provider.dart' show isBareMetalServerRunningProvider;
 import '../widgets/omi_device_section.dart';
@@ -43,33 +42,6 @@ class SettingsScreen extends ConsumerStatefulWidget {
 }
 
 class _SettingsScreenState extends ConsumerState<SettingsScreen> {
-  bool _isLoading = true;
-  String _vaultPath = '';
-  String _dailyFolderName = '';
-  String _chatFolderName = '';
-
-  @override
-  void initState() {
-    super.initState();
-    _loadSettings();
-  }
-
-  Future<void> _loadSettings() async {
-    // Load vault path and folder names
-    final dailyService = ref.read(dailyFileSystemServiceProvider);
-    await dailyService.initialize();
-    _vaultPath = await dailyService.getVaultPathDisplay();
-    _dailyFolderName = await dailyService.getModuleFolderName();
-
-    final chatService = ref.read(chatFileSystemServiceProvider);
-    await chatService.initialize();
-    _chatFolderName = await chatService.getModuleFolderName();
-
-    if (mounted) {
-      setState(() => _isLoading = false);
-    }
-  }
-
   /// Builds model selection widget — dynamic picker when supervisor is available.
   Widget _buildModelSection() {
     final isDark = Theme.of(context).brightness == Brightness.dark;
@@ -124,13 +96,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final showServerSettings = !isDailyOnlyFlavor;
     final showFullModeSettings = showServerSettings && showChatFolder;
     final showComputerControls = showServerSettings && isComputerFlavor && (Platform.isMacOS || Platform.isLinux);
-
-    if (_isLoading) {
-      return Scaffold(
-        appBar: AppBar(title: const Text('Settings')),
-        body: const Center(child: CircularProgressIndicator()),
-      );
-    }
 
     return Scaffold(
       appBar: AppBar(
@@ -195,12 +160,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           // Vault Section (always shown)
           SettingsCard(
             isDark: isDark,
-            child: VaultSettingsSection(
-              vaultPath: _vaultPath,
-              dailyFolderName: _dailyFolderName,
-              chatFolderName: _chatFolderName,
-              showChatFolder: showChatFolder,
-            ),
+            child: const VaultSettingsSection(),
           ),
 
           // Sync Section (remote clients only)

--- a/app/lib/features/settings/widgets/vault_settings_section.dart
+++ b/app/lib/features/settings/widgets/vault_settings_section.dart
@@ -16,20 +16,7 @@ final _importStatusProvider = FutureProvider.autoDispose<Map<String, dynamic>?>(
 /// journal files. The vault path concept is no longer user-configurable;
 /// audio files are now stored on the server at ~/.parachute/daily/assets/.
 class VaultSettingsSection extends ConsumerStatefulWidget {
-  // Parameters kept for API compatibility but no longer used in the UI.
-  // They will be removed in a follow-up cleanup once all callers are updated.
-  final String vaultPath;
-  final String dailyFolderName;
-  final String chatFolderName;
-  final bool showChatFolder;
-
-  const VaultSettingsSection({
-    super.key,
-    required this.vaultPath,
-    required this.dailyFolderName,
-    required this.chatFolderName,
-    required this.showChatFolder,
-  });
+  const VaultSettingsSection({super.key});
 
   @override
   ConsumerState<VaultSettingsSection> createState() => _VaultSettingsSectionState();


### PR DESCRIPTION
## Summary

- Removed 4 dead constructor params (`vaultPath`, `dailyFolderName`, `chatFolderName`, `showChatFolder`) from `VaultSettingsSection` — widget body never read them
- Removed the loading machinery that existed solely to populate them: `_isLoading`, `_loadSettings`, `dailyFileSystemServiceProvider`/`chatFileSystemServiceProvider` calls, and the `file_system_provider.dart` import
- Net: **-53 lines**, no behaviour change

Closes #174

## Testing

- `flutter analyze lib/features/settings/` — no new issues
- All 13 pre-existing warnings are in other files (unrelated)

---

Generated with [Claude Code](https://claude.com/claude-code)