### PR TITLE
refactor(computer): context system cleanup — naming collisions + bug fix

### DIFF
--- a/computer/parachute/api/imports.py
+++ b/computer/parachute/api/imports.py
@@ -344,7 +344,7 @@ async def list_context_files(request: Request) -> ContextFilesResponse:
         total_history += len(ctx.history)
 
         file_list.append({
-            "path": str(ctx.path.relative_to(vault_path)),
+            "path": str(ctx.path.relative_to(Path.home())),
             "name": ctx.name,
             "description": ctx.description,
             "facts_count": len(ctx.facts),

--- a/computer/parachute/core/context_folders.py
+++ b/computer/parachute/core/context_folders.py
@@ -15,13 +15,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+from ..lib.constants import CHARS_PER_TOKEN
+
 logger = logging.getLogger(__name__)
 
 # File names we look for (in priority order)
 CONTEXT_FILE_NAMES = ["AGENTS.md", "CLAUDE.md"]
-
-# Rough estimate: 4 chars per token
-CHARS_PER_TOKEN = 4
 
 
 @dataclass

--- a/computer/parachute/core/context_parser.py
+++ b/computer/parachute/core/context_parser.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class ContextFile:
+class ParsedContextFile:
     """Parsed representation of a context file."""
 
     path: Path
@@ -49,10 +49,10 @@ class ContextParser:
         self.vault_path = vault_path
         self.contexts_dir = vault_path / "Chat" / "contexts"
 
-    def parse_file(self, file_path: Path) -> ContextFile:
+    def parse_file(self, file_path: Path) -> ParsedContextFile:
         """Parse a context file into structured representation."""
         if not file_path.exists():
-            return ContextFile(path=file_path, name=file_path.stem)
+            return ParsedContextFile(path=file_path, name=file_path.stem)
 
         content = file_path.read_text(encoding="utf-8")
 
@@ -74,7 +74,7 @@ class ContextParser:
         except Exception:
             last_modified = None
 
-        return ContextFile(
+        return ParsedContextFile(
             path=file_path,
             name=name,
             description=description,
@@ -110,7 +110,7 @@ class ContextParser:
                     bullets.append(bullet_text)
         return bullets
 
-    def list_context_files(self) -> list[ContextFile]:
+    def list_context_files(self) -> list[ParsedContextFile]:
         """List all context files with basic info."""
         files = []
 

--- a/computer/parachute/core/orchestrator.py
+++ b/computer/parachute/core/orchestrator.py
@@ -1501,6 +1501,8 @@ class Orchestrator:
             file_paths: list[str] = []
 
             for ctx in contexts:
+                # .md entries are individual files → loaded by context_loader (lib/)
+                # everything else is a folder path → walked by context_folders (core/)
                 if ctx.endswith(".md"):
                     file_paths.append(ctx)
                 else:

--- a/computer/parachute/lib/constants.py
+++ b/computer/parachute/lib/constants.py
@@ -1,0 +1,7 @@
+"""
+Shared constants for the Parachute server.
+"""
+
+# Rough estimate used for token-budget calculations throughout the context system.
+# Average English token is ~4 characters; this is intentionally approximate.
+CHARS_PER_TOKEN = 4

--- a/computer/parachute/lib/context_loader.py
+++ b/computer/parachute/lib/context_loader.py
@@ -10,10 +10,9 @@ from typing import Any, Optional
 
 import frontmatter
 
-logger = logging.getLogger(__name__)
+from .constants import CHARS_PER_TOKEN
 
-# Rough estimate: 4 chars per token
-CHARS_PER_TOKEN = 4
+logger = logging.getLogger(__name__)
 
 
 async def load_agent_context(

--- a/docs/plans/2026-03-04-refactor-context-system-cleanup-plan.md
+++ b/docs/plans/2026-03-04-refactor-context-system-cleanup-plan.md
@@ -1,0 +1,95 @@
+---
+title: "Cleanup: Context system naming collisions and duplicated constants"
+type: refactor
+date: 2026-03-04
+issue: 83
+priority: P3
+labels: [computer]
+---
+
+# Context System Cleanup
+
+Small housekeeping pass on the three context subsystems in `computer/`. No behavior changes — naming, placement, and one actual bug fix.
+
+## Acceptance Criteria
+
+- [x] `CHARS_PER_TOKEN = 4` exists in exactly one place (`lib/constants.py`)
+- [x] `context_loader.py` and `context_folders.py` both import it from there
+- [x] `ContextFile` in `context_parser.py` renamed to `ParsedContextFile`; all references updated
+- [x] `imports.py` `GET /import/contexts` endpoint no longer crashes with `NameError` on `vault_path`
+- [x] Orchestrator `_build_system_prompt()` routing has a clarifying comment
+- [x] All unit tests pass
+
+## Changes
+
+### 1. Extract `CHARS_PER_TOKEN` → `parachute/lib/constants.py` (new file)
+
+```python
+# parachute/lib/constants.py
+# Rough token estimation: average English word ≈ 4 chars, avg token ≈ 4 chars
+CHARS_PER_TOKEN = 4
+```
+
+Update imports:
+- `lib/context_loader.py:16` — remove local definition, `from .constants import CHARS_PER_TOKEN`
+- `core/context_folders.py:24` — remove local definition, `from ..lib.constants import CHARS_PER_TOKEN`
+
+### 2. Rename `ContextFile` → `ParsedContextFile` in `context_parser.py`
+
+`context_parser.py` has `ContextFile` (a structured parsed context with facts/focus/history).
+`context_folders.py` has `ContextFile` (a single file in a folder hierarchy chain).
+Both names are correct for their domain, but two `ContextFile`s in the same codebase is a navigation hazard.
+
+Rename the parser's class to `ParsedContextFile` — the smaller blast radius since only `imports.py` consumes it.
+
+Files touched:
+- `core/context_parser.py` — rename class + 3 method references
+- `api/imports.py` — update the one import + any `ContextFile` references
+
+### 3. Fix `NameError` in `GET /import/contexts` endpoint (`api/imports.py:347`)
+
+**Bug:** `vault_path` is referenced but never defined in `list_context_files()`.
+
+```python
+# Current (crashes with NameError):
+"path": str(ctx.path.relative_to(vault_path)),
+
+# Fix: use the same root the parser was initialized with
+"path": str(ctx.path.relative_to(Path.home())),
+```
+
+The parser is initialized with `ContextParser(Path.home())` three lines above, so `Path.home()` is the correct root. If the vault path ever becomes configurable here, both the parser init and this line should move together.
+
+### 4. Add routing comment in `orchestrator._build_system_prompt()`
+
+The current dispatch is:
+```python
+if ctx.endswith(".md"):
+    file_paths.append(ctx)
+else:
+    folder_paths.append(ctx)
+```
+
+Add a comment explaining the convention — `.md` entries are individual files loaded via `context_loader`, everything else is a folder path walked by `context_folders`. No code change.
+
+## Context
+
+```
+computer/parachute/
+├── lib/
+│   ├── constants.py         ← NEW
+│   └── context_loader.py    ← imports CHARS_PER_TOKEN from constants
+├── core/
+│   ├── context_folders.py   ← imports CHARS_PER_TOKEN from lib.constants
+│   │                           ContextFile class stays as-is
+│   ├── context_parser.py    ← ContextFile → ParsedContextFile
+│   └── orchestrator.py      ← comment added to _build_system_prompt()
+└── api/
+    └── imports.py           ← vault_path bug fixed, ParsedContextFile import updated
+```
+
+## What We're Not Doing
+
+- Not consolidating the three context systems — they serve distinct purposes
+- Not changing `context_folders.ContextFile` (larger blast radius, less confusing name)
+- Not making the orchestrator routing more elaborate — a comment is enough at P3


### PR DESCRIPTION
## Summary

- **New `lib/constants.py`**: `CHARS_PER_TOKEN = 4` now lives in one place; `context_loader.py` and `context_folders.py` both import from it
- **`ParsedContextFile`**: renamed from `ContextFile` in `context_parser.py` to resolve the naming collision with the identically-named class in `context_folders.py`; only consumer is `imports.py`
- **Bug fix**: `GET /import/contexts` was crashing with `NameError: name 'vault_path' is not defined` — fixed to use `Path.home()` (matching the `ContextParser` init three lines above)
- **Routing comment**: `orchestrator._build_system_prompt()` now has a comment explaining the `.md` file vs folder path dispatch convention

No behavior changes except the `NameError` fix (which makes the endpoint functional).

Closes #83

## Testing

- 480 unit tests pass (excluding pre-existing flaky WAL recovery test in `test_daily_module.py`)
- Import verification: all three modules resolve to the same `CHARS_PER_TOKEN` object from `constants.py`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)