### PR TITLE
refactor(mcp): streamline tool surface — cleaner names, exchange search, simple primitives

### DIFF
--- a/computer/parachute/api/brain.py
+++ b/computer/parachute/api/brain.py
@@ -33,14 +33,18 @@ def _get_graph():
 
 
 def _extract_snippet(content: str, query: str, window: int = 200) -> str:
-    """Extract ~200-char snippet centered around the first match of query in content."""
+    """Extract a snippet of up to `window` chars centered around the first match.
+
+    If no match is found, returns the first `window` chars.
+    """
     if not content:
         return ""
     pos = content.lower().find(query.lower())
     if pos < 0:
         return content[:window] + ("..." if len(content) > window else "")
-    start = max(0, pos - 80)
-    end = min(len(content), pos + len(query) + 120)
+    half = window // 2
+    start = max(0, pos - half)
+    end = min(len(content), pos + len(query) + half)
     snippet = content[start:end]
     if start > 0:
         snippet = "..." + snippet
@@ -177,6 +181,7 @@ async def get_session(
             e["ai_response"] = _truncate(e.get("ai_response"), max_chars)
             exchanges.append(e)
     except Exception:
+        logger.exception("Failed to fetch exchanges for session %s", session_id)
         exchanges = []
 
     return {"session": session, "exchanges": exchanges, "exchange_count": len(exchanges)}
@@ -184,7 +189,7 @@ async def get_session(
 
 @router.get("/exchanges")
 async def get_exchange(
-    id: str = Query(..., description="Exchange ID (e.g. session_id:ex:N)"),
+    exchange_id: str = Query(..., alias="id", description="Exchange ID (e.g. session_id:ex:N)"),
 ):
     """Get a single exchange by ID with full message content.
 
@@ -195,10 +200,10 @@ async def get_exchange(
 
     rows = await graph.execute_cypher(
         "MATCH (e:Exchange {exchange_id: $exchange_id}) RETURN e",
-        {"exchange_id": id},
+        {"exchange_id": exchange_id},
     )
     if not rows:
-        raise HTTPException(status_code=404, detail=f"Exchange not found: {id}")
+        raise HTTPException(status_code=404, detail=f"Exchange not found: {exchange_id}")
 
     return {"exchange": rows[0]}
 
@@ -344,7 +349,7 @@ async def get_memory(
                     "snippet": row.get("matched_description") or "",
                     "matched_exchange_id": row.get("matched_exchange_id") or "",
                     "ts": row.get("last_accessed") or row.get("created_at") or "",
-"module": row.get("module") or "chat",
+                    "module": row.get("module") or "chat",
                 })
 
     if type != "sessions":

--- a/computer/parachute/mcp_server.py
+++ b/computer/parachute/mcp_server.py
@@ -39,7 +39,7 @@ import httpx
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Optional, Self
+from typing import Any, Self
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -117,17 +117,11 @@ async def get_db():
     return _db
 
 
-def _get_brain():
-    """Return the live BrainService from the registry, or None if unavailable."""
-    from parachute.core.interfaces import get_registry
-    return get_registry().get("BrainDB")
-
-
 def _validate_message_content(
     content: str,
     field_name: str = "message",
     max_length: int = 50_000
-) -> Optional[str]:
+) -> str | None:
     """Validate message content.
 
     Returns:
@@ -421,7 +415,7 @@ TOOLS = [
 async def get_session(
     session_id: str,
     include_messages: bool = True,
-) -> Optional[dict[str, Any]]:
+) -> dict[str, Any] | None:
     """Get a session by ID with optional messages."""
     db = await get_db()
     session = await db.get_session(session_id)
@@ -702,20 +696,6 @@ async def handle_tool_call(name: str, arguments: dict[str, Any]) -> str:
             params["limit"] = arguments.get("limit", 10)
             qs = "?" + urllib.parse.urlencode(params)
             result = await _brain_call(f"/memory{qs}")
-        elif name == "search_sessions":
-            # Route through brain API — avoids DB file lock conflict
-            sp: dict[str, Any] = {"search": arguments["query"], "limit": arguments.get("limit", 10)}
-            qs = "?" + urllib.parse.urlencode(sp)
-            result = await _brain_call(f"/sessions{qs}")
-        elif name == "list_recent_sessions":
-            # Route through brain API — avoids DB file lock conflict
-            lp: dict[str, Any] = {"limit": arguments.get("limit", 20)}
-            if arguments.get("module"):
-                lp["module"] = arguments["module"]
-            if arguments.get("archived"):
-                lp["archived"] = "true"
-            qs = "?" + urllib.parse.urlencode(lp)
-            result = await _brain_call(f"/sessions{qs}")
         elif name == "get_session":
             result = await get_session(
                 session_id=arguments["session_id"],


### PR DESCRIPTION
## Summary

Follow-up to #204. Refines the MCP tool surface toward simpler, more consistent primitives.

- **Cleaner names**: `brain_list_chats`, `brain_get_chat`, `brain_list_notes` replace the old `*_sessions`/`*_entries` names
- **Exchange search**: `search_memory` now searches full exchange content (user_message, ai_response, description); returns matched parent Chat with `matched_exchange_id` for drill-down
- **`brain_get_exchange`**: new primitive for fetching a single exchange with full untruncated content — the second level of two-level retrieval
- **`brain_get_chat` pagination**: `exchange_limit` (default 25) + `max_chars` (default 2000) keep large sessions manageable
- **Tool removal**: `search_sessions`, `list_recent_sessions`, `search_journals`, `list_recent_journals`, `get_journal` fully removed — superseded by `search_memory` + `brain_list_chats` + `brain_list_notes`
- **Dead code removed**: 200+ lines of markdown-file-reading journal functions that no longer had callers

## API changes (`api/brain.py`)

- `GET /sessions/{id}` — new `exchange_limit` and `max_chars` query params; truncates message fields; reverses to chronological order
- `GET /exchanges?id=...` — new endpoint for single-exchange lookup with full content
- `GET /memory` — now searches Exchange nodes in addition to Chat + Note; deduplicates session results; includes `matched_exchange_id`

## Test plan

- [ ] `search_memory` returns sessions matched via exchange content (not just title/summary)
- [ ] `search_memory` result includes `matched_exchange_id` for exchange-matched sessions
- [ ] `brain_get_chat` respects `exchange_limit` and `max_chars` params
- [ ] `brain_get_exchange` returns full untruncated content for a known exchange ID
- [ ] `brain_list_chats`, `brain_list_notes` work as expected (renamed from old tools)
- [ ] Removed tools (`search_sessions`, `list_recent_journals`, etc.) no longer appear in MCP tool list

Closes #203 (follow-up to #204)

🤖 Generated with [Claude Code](https://claude.com/claude-code)