### PR TITLE
feat(app): agent completion notifications

### DIFF
--- a/app/lib/features/chat/providers/agent_completion_provider.dart
+++ b/app/lib/features/chat/providers/agent_completion_provider.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:parachute/core/providers/app_state_provider.dart';
+import 'package:parachute/features/chat/providers/chat_session_providers.dart';
+import 'package:parachute/features/daily/recorder/services/notification_service.dart';
+
+// ============================================================
+// App Lifecycle Tracking
+// ============================================================
+
+/// Tracks whether the app is in the foreground or background.
+/// Updated from _TabShellState.didChangeAppLifecycleState().
+final appLifecycleProvider = StateProvider<AppLifecycleState>((ref) {
+  return AppLifecycleState.resumed; // Assume foreground on startup
+});
+
+// ============================================================
+// Agent Completion Events
+// ============================================================
+
+/// A single agent completion event for toast display.
+class AgentCompletionEvent {
+  final String sessionId;
+  final String title;
+  final DateTime completedAt;
+
+  const AgentCompletionEvent({
+    required this.sessionId,
+    required this.title,
+    required this.completedAt,
+  });
+}
+
+/// State for agent completion notifications.
+class AgentCompletionState {
+  final int unreadCount;
+  final AgentCompletionEvent? latestEvent;
+
+  const AgentCompletionState({
+    this.unreadCount = 0,
+    this.latestEvent,
+  });
+
+  AgentCompletionState copyWith({
+    int? unreadCount,
+    AgentCompletionEvent? latestEvent,
+  }) {
+    return AgentCompletionState(
+      unreadCount: unreadCount ?? this.unreadCount,
+      latestEvent: latestEvent ?? this.latestEvent,
+    );
+  }
+}
+
+/// Centralized notifier for agent completion notifications.
+///
+/// Receives completion events from DoneEvent handlers and decides which
+/// surface(s) to fire based on app state:
+/// - App backgrounded → OS notification
+/// - On different tab → increment badge + show toast
+/// - On chat tab, different session → show toast only
+/// - Viewing that session → nothing
+class AgentCompletionNotifier extends Notifier<AgentCompletionState> {
+  @override
+  AgentCompletionState build() {
+    return const AgentCompletionState();
+  }
+
+  /// Called when an agent finishes responding.
+  void onCompleted(String sessionId, String? title) {
+    final displayTitle = (title != null && title.isNotEmpty) ? title : 'Chat';
+
+    // Determine app state
+    final lifecycle = ref.read(appLifecycleProvider);
+    final isBackgrounded = lifecycle == AppLifecycleState.paused ||
+        lifecycle == AppLifecycleState.inactive ||
+        lifecycle == AppLifecycleState.detached;
+
+    final currentTab = ref.read(currentTabIndexProvider);
+    final visibleTabs = ref.read(visibleTabsProvider);
+    final isOnChatTab = currentTab < visibleTabs.length &&
+        visibleTabs[currentTab] == AppTab.chat;
+
+    final currentSessionId = ref.read(currentSessionIdProvider);
+    final isViewingSession = isOnChatTab && currentSessionId == sessionId;
+
+    debugPrint('[AgentCompletion] onCompleted: session=$sessionId, '
+        'title="$displayTitle", backgrounded=$isBackgrounded, '
+        'onChatTab=$isOnChatTab, viewingSession=$isViewingSession');
+
+    // If viewing the completed session, no notification needed
+    if (isViewingSession && !isBackgrounded) {
+      return;
+    }
+
+    final event = AgentCompletionEvent(
+      sessionId: sessionId,
+      title: displayTitle,
+      completedAt: DateTime.now(),
+    );
+
+    if (isBackgrounded) {
+      // App is backgrounded — fire OS notification
+      _fireOsNotification(displayTitle, sessionId);
+      // Also increment badge for when they return
+      state = AgentCompletionState(
+        unreadCount: state.unreadCount + 1,
+        latestEvent: event,
+      );
+    } else if (!isOnChatTab) {
+      // On a different tab — badge + toast
+      state = AgentCompletionState(
+        unreadCount: state.unreadCount + 1,
+        latestEvent: event,
+      );
+    } else {
+      // On chat tab but different session — toast only
+      state = AgentCompletionState(
+        unreadCount: state.unreadCount,
+        latestEvent: event,
+      );
+    }
+  }
+
+  /// Clear unread count (called when user switches to Chat tab).
+  void clearUnread() {
+    if (state.unreadCount > 0) {
+      state = AgentCompletionState(
+        unreadCount: 0,
+        latestEvent: state.latestEvent,
+      );
+    }
+  }
+
+  /// Fire an Android/iOS local notification.
+  void _fireOsNotification(String title, String sessionId) {
+    final notificationService = NotificationService();
+    notificationService.showAgentCompleted(title, sessionId: sessionId);
+  }
+}
+
+/// Provider for agent completion notifications.
+final agentCompletionProvider =
+    NotifierProvider<AgentCompletionNotifier, AgentCompletionState>(
+  AgentCompletionNotifier.new,
+);

--- a/app/lib/features/chat/providers/chat_message_providers.dart
+++ b/app/lib/features/chat/providers/chat_message_providers.dart
@@ -15,6 +15,7 @@ import 'package:parachute/core/services/logging_service.dart';
 import 'package:parachute/core/providers/core_service_providers.dart';
 import 'package:parachute/core/providers/supervisor_providers.dart' show supervisorConfigProvider;
 import 'chat_session_actions.dart' show newChatModeProvider;
+import 'agent_completion_provider.dart';
 import 'chat_session_providers.dart';
 import 'project_providers.dart' show activeProjectProvider;
 
@@ -787,6 +788,11 @@ class ChatMessagesNotifier extends StateNotifier<ChatMessagesState> {
         _updateOrAddAssistantMessage(_reattachStreamContent, sessionId, isStreaming: false);
         _reattachStreamContent = []; // Reset for next stream
         state = state.copyWith(isStreaming: false);
+        // Notify completion for toast/badge/OS notification
+        _ref.read(agentCompletionProvider.notifier).onCompleted(
+          sessionId,
+          event.sessionTitle ?? state.sessionTitle,
+        );
         // Reload to get final state
         loadSession(sessionId);
         break;
@@ -1526,6 +1532,12 @@ class ChatMessagesNotifier extends StateNotifier<ChatMessagesState> {
         }
         // Always refresh sessions list to get updated title
         _ref.invalidate(chatSessionsProvider);
+
+        // Notify completion for toast/badge/OS notification
+        _ref.read(agentCompletionProvider.notifier).onCompleted(
+          state.sessionId ?? ctx.actualSessionId ?? '',
+          doneTitle ?? state.sessionTitle,
+        );
 
         // Flush any queued messages (submitted while streaming was active).
         // Also handle the legacy single-message resend path.

--- a/app/lib/features/daily/journal/providers/journal_providers.dart
+++ b/app/lib/features/daily/journal/providers/journal_providers.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/providers/file_system_provider.dart';
 import 'package:parachute/core/providers/feature_flags_provider.dart' show aiServerUrlProvider;

--- a/app/lib/features/daily/recorder/services/notification_service.dart
+++ b/app/lib/features/daily/recorder/services/notification_service.dart
@@ -4,7 +4,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 /// Service for managing local notifications
 ///
-/// Used to show recording status when app is in background.
+/// Used to show recording status and agent completion alerts.
 /// Note: Only available on iOS and Android, gracefully degrades on macOS.
 class NotificationService {
   static final NotificationService _instance = NotificationService._internal();
@@ -76,17 +76,25 @@ class NotificationService {
   Future<void> _createNotificationChannels() async {
     if (!Platform.isAndroid) return;
 
-    const channel = AndroidNotificationChannel(
+    final androidPlugin = _notifications
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+
+    const recordingChannel = AndroidNotificationChannel(
       'omi_recording',
       'Omi Recording',
       description: 'Notifications for Omi device recording status',
       importance: Importance.high,
     );
+    await androidPlugin?.createNotificationChannel(recordingChannel);
 
-    await _notifications
-        .resolvePlatformSpecificImplementation<
-            AndroidFlutterLocalNotificationsPlugin>()
-        ?.createNotificationChannel(channel);
+    const agentChannel = AndroidNotificationChannel(
+      'agent_completion',
+      'Agent Updates',
+      description: 'Notifications when chat agents finish responding',
+      importance: Importance.defaultImportance,
+    );
+    await androidPlugin?.createNotificationChannel(agentChannel);
   }
 
   /// Handle notification tap
@@ -160,6 +168,25 @@ class NotificationService {
     }
   }
 
+  /// Show agent completion notification
+  Future<void> showAgentCompleted(String sessionTitle, {String? sessionId}) async {
+    if (!_isSupported || !_isInitialized) return;
+
+    try {
+      // Use session ID hash for notification ID so each session gets its own notification
+      final notificationId = sessionId?.hashCode.abs() ?? 100;
+      await _notifications.show(
+        notificationId,
+        '$sessionTitle \u2014 finished',
+        'Tap to return to chat',
+        _agentCompletionDetails(),
+        payload: sessionId,
+      );
+    } catch (e) {
+      debugPrint('[NotificationService] Error showing agent notification: $e');
+    }
+  }
+
   /// Cancel all notifications
   Future<void> cancelAll() async {
     if (!_isSupported || !_isInitialized) return;
@@ -182,7 +209,26 @@ class NotificationService {
     }
   }
 
-  /// Build notification details
+  /// Build notification details for agent completion
+  NotificationDetails _agentCompletionDetails() {
+    return const NotificationDetails(
+      android: AndroidNotificationDetails(
+        'agent_completion',
+        'Agent Updates',
+        channelDescription: 'Notifications when chat agents finish responding',
+        importance: Importance.defaultImportance,
+        priority: Priority.defaultPriority,
+        autoCancel: true,
+      ),
+      iOS: DarwinNotificationDetails(
+        presentAlert: true,
+        presentBadge: true,
+        presentSound: false,
+      ),
+    );
+  }
+
+  /// Build notification details for recording
   NotificationDetails _notificationDetails({bool ongoing = false}) {
     return NotificationDetails(
       android: AndroidNotificationDetails(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -28,6 +28,7 @@ import 'features/daily/recorder/providers/omi_providers.dart';
 import 'features/chat/screens/chat_hub_screen.dart';
 import 'features/chat/screens/chat_shell.dart';
 import 'features/chat/screens/chat_screen.dart';
+import 'features/chat/providers/agent_completion_provider.dart';
 import 'features/chat/providers/chat_providers.dart';
 import 'features/chat/widgets/message_bubble.dart' show currentlyRenderingMarkdown, markMarkdownAsFailed;
 import 'features/daily/journal/providers/journal_providers.dart';
@@ -259,15 +260,17 @@ class _TabShellState extends ConsumerState<_TabShell> with WidgetsBindingObserve
 
   Widget _buildChatTabIcon(bool isDark, bool selected) {
     final pendingCount = ref.watch(pendingPairingCountProvider).valueOrNull ?? 0;
+    final completionCount = ref.watch(agentCompletionProvider).unreadCount;
+    final badgeCount = pendingCount + completionCount;
     final icon = Icon(
       selected ? Icons.chat_bubble : Icons.chat_bubble_outline,
       color: selected
           ? (isDark ? BrandColors.nightTurquoise : BrandColors.turquoise)
           : (isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood),
     );
-    if (pendingCount > 0) {
+    if (badgeCount > 0) {
       return Badge(
-        label: Text('$pendingCount'),
+        label: Text('$badgeCount'),
         child: icon,
       );
     }
@@ -451,6 +454,9 @@ class _TabShellState extends ConsumerState<_TabShell> with WidgetsBindingObserve
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Track lifecycle for agent completion notifications
+    ref.read(appLifecycleProvider.notifier).state = state;
+
     // Handle sync lifecycle
     final syncAvailable = ref.read(syncAvailableProvider);
     if (syncAvailable) {
@@ -540,6 +546,20 @@ class _TabShellState extends ConsumerState<_TabShell> with WidgetsBindingObserve
       next.whenData((target) {
         _handleDeepLink(target);
       });
+    });
+
+    // Listen for agent completion events to show toast
+    ref.listen<AgentCompletionState>(agentCompletionProvider, (previous, next) {
+      if (next.latestEvent != null &&
+          next.latestEvent != previous?.latestEvent) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('${next.latestEvent!.title} \u2014 finished'),
+            duration: const Duration(seconds: 3),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
     });
 
     final appMode = ref.watch(appModeProvider);
@@ -660,6 +680,12 @@ class _TabShellState extends ConsumerState<_TabShell> with WidgetsBindingObserve
                   // Map visual index back to actual tab index
                   final newActualIndex = showAllTabs ? index : 1;
                   ref.read(currentTabIndexProvider.notifier).state = newActualIndex;
+                  // Clear completion badge when switching to Chat tab
+                  final visibleTabs = ref.read(visibleTabsProvider);
+                  if (newActualIndex < visibleTabs.length &&
+                      visibleTabs[newActualIndex] == AppTab.chat) {
+                    ref.read(agentCompletionProvider.notifier).clearUnread();
+                  }
                 },
                 backgroundColor: isDark ? BrandColors.nightSurfaceElevated : BrandColors.softWhite,
                 indicatorColor: isDark

--- a/docs/brainstorms/2026-03-08-agent-completion-notifications-brainstorm.md
+++ b/docs/brainstorms/2026-03-08-agent-completion-notifications-brainstorm.md
@@ -1,0 +1,74 @@
+# Agent Completion Notifications
+
+**Date:** 2026-03-08
+**Status:** Brainstorm
+**Priority:** P2
+**Modules:** app, computer
+**Issue:** #206
+
+---
+
+## Context
+
+The common workflow on the Daylight tablet (Android): prompt agents in the Chat tab, switch to Daily for freeform journaling, sometimes leave the app entirely for Messenger or email. Without any notification signal, it's easy to lose context and forget an agent is waiting — breaking the flow between tending agents and reflective writing.
+
+The infrastructure is already in place:
+- Server emits a typed `DoneEvent` when an agent finishes (with session title, duration, response summary)
+- Flutter `ChatMessagesState.isStreaming` already flips to `false` on completion
+- `flutter_local_notifications` plugin is installed and configured with Android notification channels (used by Daily's recording notifications)
+- Chat tab already has a `Badge` widget pattern for pending pairing count
+- Session list items already render status badges (Pending, Setup, Archived)
+
+What's missing is a notification layer that connects these signals to the user across three surfaces.
+
+---
+
+## What We're Building
+
+Three notification surfaces for agent completion, in order of depth:
+
+### 1. In-App Toast
+A brief snackbar/toast when a `DoneEvent` arrives and the user isn't looking at that session. Shows the session title + "finished." Disappears after a few seconds.
+
+**When it fires:** User is in the app (any tab, or a different chat session).
+
+### 2. Chat Tab Badge
+An unread count badge on the Chat tab icon. Increments when an agent finishes while the user is on another tab (Daily, Brain, Vault). Clears when the user navigates to the Chat tab or opens the completed session.
+
+**When it fires:** User is on a non-Chat tab within the app.
+
+### 3. Android OS Notification
+A local push notification when the app is backgrounded or the screen is off. Tapping it opens the app (ideally navigating to the completed session). Uses the existing `flutter_local_notifications` setup.
+
+**When it fires:** App is not in the foreground.
+
+Each notification shows the **session title** and a simple status like "finished."
+
+---
+
+## Why This Approach
+
+- **Incremental surfaces** — toast and badge are pure Flutter, no platform code. OS notification reuses existing plugin. Each layer is independently useful.
+- **Already-wired signals** — `DoneEvent` is the trigger. No new server work needed. The client already processes this event and flips `isStreaming`.
+- **YAGNI** — No notification center, no sound/haptic (yet), no custom notification UI. Just the minimum to solve "I forgot my agent finished."
+- **Android-first** — Primary device is the Daylight tablet. macOS desktop notifications can come later if needed.
+
+---
+
+## Key Decisions
+
+1. **Individual notifications per session** — not batched. Each agent completion gets its own toast/badge increment/OS notification with the session title.
+2. **Toast over banner** — brief snackbar, not a persistent banner. Low-interruption.
+3. **Badge clears on tab switch** — navigating to the Chat tab clears the unread count. Simple mental model.
+4. **OS notifications only when backgrounded** — no duplicate notification when the user is already looking at the app.
+5. **Tap-to-navigate** — tapping the OS notification should open the app and ideally navigate to the specific session that finished.
+6. **No new server work** — the `DoneEvent` already carries everything needed. This is a client-side feature.
+
+---
+
+## Open Questions
+
+- **Badge scope:** Should the badge count only "finished while you were away" sessions, or also sessions with unread responses in general? Starting with just completion events keeps it simple.
+- **Notification grouping:** If 3 agents finish in quick succession while backgrounded, should they be 3 separate OS notifications or grouped? Android supports notification grouping — worth doing if it's easy, but not essential for v1.
+- **macOS support:** `flutter_local_notifications` has macOS support but it's less tested. Defer to a follow-up if there's demand.
+- **Session navigation on tap:** Deep linking from OS notification to a specific chat session may need some routing work. Could start with just "open the app to the Chat tab" as a simpler first pass.


### PR DESCRIPTION
## Summary
- Adds three notification surfaces for when chat agents finish: in-app toast, Chat tab badge count, and Android OS notification
- New `AgentCompletionNotifier` centralizes the decision of which surface to fire based on app lifecycle state, current tab, and current session
- Reuses existing `flutter_local_notifications` with a new `agent_completion` Android channel
- Also fixes pre-existing build error (missing `foundation.dart` import in `journal_providers.dart`)

Closes #206

## Test plan
- [ ] Send a message to an agent, stay on that session — no notification should appear when it finishes
- [ ] Send a message, switch to a different chat session — toast should appear ("Title — finished")
- [ ] Send a message, switch to Daily tab — toast should appear AND Chat tab icon should show badge count
- [ ] Switch back to Chat tab — badge should clear
- [ ] Send a message, background the app (go to Android home/Messenger) — OS notification should appear
- [ ] Tap the OS notification — should return to the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)