### PR TITLE
feat: dynamic tool guidance for sandbox sessions

### DIFF
--- a/computer/parachute/core/orchestrator.py
+++ b/computer/parachute/core/orchestrator.py
@@ -152,6 +152,7 @@ class CapabilityBundle:
     plugin_dirs: list[Path]
     agents_dict: dict | None
     effective_trust: str
+    tool_guidance: str  # Dynamic tool guidance markdown, filtered by trust level
     warnings: list[dict] = field(default_factory=list)  # Serialized WarningEvent dicts
 
 
@@ -385,20 +386,9 @@ class Orchestrator:
             if project and project.core_memory:
                 project_memory = project.core_memory[:4000]
 
-        # Resolve trust level early for prompt building (same logic as _discover_capabilities)
-        from parachute.core.trust import normalize_trust_level
-
-        if trust_level:
-            try:
-                prompt_trust = normalize_trust_level(trust_level)
-            except ValueError:
-                prompt_trust = session.get_trust_level().value
-        elif session.trust_level:
-            prompt_trust = session.get_trust_level().value
-        else:
-            prompt_trust = "direct"
-
         # Build system prompt (after loading prior conversation, with working dir)
+        # Note: tool guidance is injected later, after capability discovery resolves
+        # the trust level and generates the filtered tool guidance markdown.
         # Only surface credential discoverability for non-bot sessions — bot sessions
         # receive empty credentials, so advertising pre-authenticated tools would mislead the agent.
         prompt_cred_keys = (
@@ -415,7 +405,6 @@ class Orchestrator:
             credential_keys=prompt_cred_keys,
             mode=effective_mode,
             project_memory=project_memory,
-            trust_level=prompt_trust,
         )
 
         logger.info(
@@ -489,6 +478,11 @@ class Orchestrator:
         try:
             # Phase 2: Capability discovery
             caps = await self._discover_capabilities(agent, session, trust_level)
+
+            # Inject trust-filtered tool guidance into the prompt
+            # (skipped for custom/agent prompts — those manage their own tool docs)
+            if caps.tool_guidance and prompt_metadata.get("prompt_source") not in ("custom", "agent"):
+                effective_prompt = f"{effective_prompt}\n\n{caps.tool_guidance}"
 
             # converse mode always uses a full replacement prompt (no Claude Code preset)
             is_full_prompt = prompt_metadata.get("prompt_source") in ("custom", "agent", "converse")
@@ -871,6 +865,7 @@ class Orchestrator:
             plugin_dirs=plugin_dirs,
             agents_dict=agents_dict,
             effective_trust=effective_trust,
+            tool_guidance=build_tool_guidance(effective_trust),
             warnings=warnings,
         )
 
@@ -1584,17 +1579,18 @@ class Orchestrator:
         credential_keys: Optional[set[str]] = None,
         mode: str = "converse",
         project_memory: Optional[str] = None,
-        trust_level: Optional[str] = None,
     ) -> tuple[str, dict[str, Any]]:
         """
         Build the system prompt additions.
 
         The SDK handles project-level discovery (CLAUDE.md, .claude/ commands/skills/agents)
         via setting_sources=["project"]. This method builds additional content:
-        - Dynamic tool guidance (filtered by trust level)
         - Vault-level CLAUDE.md (outside the project root)
         - Prior conversation history (runtime only)
         - Explicitly selected context files
+
+        Note: Dynamic tool guidance is injected separately by run_streaming()
+        after capability discovery resolves the trust level.
 
         For converse mode: returns CONVERSE_PROMPT as a full replacement (no preset).
         For cocreate mode: returns COCREATE_PROMPT_APPEND appended to Claude Code preset.
@@ -1654,11 +1650,6 @@ class Orchestrator:
                         metadata["prompt_source_path"] = "CLAUDE.md"
                 except OSError as e:
                     logger.warning(f"Failed to read vault CLAUDE.md: {e}")
-
-        # Dynamic tool guidance — filtered by trust level
-        tool_guidance = build_tool_guidance(trust_level or "direct")
-        if tool_guidance:
-            append_parts.append(tool_guidance)
 
         # Project context (core_memory from Project node) — injected after mode framing
         if project_memory:

--- a/computer/parachute/core/tool_guidance.py
+++ b/computer/parachute/core/tool_guidance.py
@@ -9,17 +9,28 @@ tool documentation with usage guidance.
 
 from __future__ import annotations
 
+from typing import Literal, TypedDict
+
 from parachute.core.capability_filter import TRUST_ORDER, trust_rank
 
-# ---------------------------------------------------------------------------
-# Tool groups — each group has:
-#   name:     display label
-#   trust:    minimum trust level ("sandboxed" = everywhere, "direct" = trusted only)
-#   guidance: contextual usage guidance (when/why to use these tools)
-#   tools:    list of {name, description} dicts
-# ---------------------------------------------------------------------------
 
-TOOL_GROUPS: list[dict] = [
+class ToolEntry(TypedDict):
+    """A single MCP tool with its name and description."""
+
+    name: str
+    description: str
+
+
+class ToolGroup(TypedDict):
+    """A group of related MCP tools with shared trust level and usage guidance."""
+
+    name: str
+    trust: Literal["direct", "sandboxed"]
+    guidance: str
+    tools: list[ToolEntry]
+
+
+TOOL_GROUPS: list[ToolGroup] = [
     {
         "name": "Memory Search",
         "trust": "sandboxed",

--- a/computer/tests/unit/test_orchestrator_phases.py
+++ b/computer/tests/unit/test_orchestrator_phases.py
@@ -86,6 +86,7 @@ def _make_caps(**overrides) -> CapabilityBundle:
         plugin_dirs=[],
         agents_dict=None,
         effective_trust="direct",
+        tool_guidance="",
         warnings=[],
     )
     defaults.update(overrides)

--- a/computer/tests/unit/test_tool_guidance.py
+++ b/computer/tests/unit/test_tool_guidance.py
@@ -108,20 +108,23 @@ class TestBuildToolGuidance:
         # Check for guidance from the Brain: Browse group
         assert "Browse and read past conversations" in result
 
-    def test_empty_string_when_no_groups_match(self):
-        """Should return empty string if no groups match (edge case)."""
-        # This shouldn't happen with current TRUST_ORDER, but test the behavior
-        # by monkeypatching would be complex — just verify non-empty for valid levels
-        assert build_tool_guidance("direct") != ""
-        assert build_tool_guidance("sandboxed") != ""
+    def test_empty_string_when_no_groups_match(self, monkeypatch):
+        """Should return empty string if no tool groups match the trust level."""
+        monkeypatch.setattr("parachute.core.tool_guidance.TOOL_GROUPS", [])
+        assert build_tool_guidance("direct") == ""
+        assert build_tool_guidance("sandboxed") == ""
 
     def test_direct_is_superset_of_sandboxed(self):
-        """Direct guidance should contain everything sandboxed has, plus more."""
+        """Direct guidance should contain every sandboxed group plus direct-only groups."""
         direct = build_tool_guidance("direct")
         sandboxed = build_tool_guidance("sandboxed")
-        assert len(direct) > len(sandboxed)
-        # Every sandboxed tool group should appear in direct
+        # Every sandboxed tool group must appear in both outputs
         for group in TOOL_GROUPS:
             if group["trust"] == "sandboxed":
                 assert group["name"] in direct
                 assert group["name"] in sandboxed
+        # Direct-only groups must appear only in direct output
+        for group in TOOL_GROUPS:
+            if group["trust"] == "direct":
+                assert group["name"] in direct
+                assert group["name"] not in sandboxed


### PR DESCRIPTION
## Summary

- Replaces stale hardcoded vault tool list in system prompts with a dynamic guidance system filtered by trust level
- Brain read tools (`search_memory`, `brain_list_chats`, `brain_get_chat`, `brain_list_notes`, etc.) are now properly surfaced in sandboxed sessions with contextual usage guidance
- Removes 6 references to tools that no longer exist (`search_sessions`, `list_recent_sessions`, `search_journals`, etc.)
- `brain_query` and `brain_execute` remain gated to direct-only sessions (matching existing MCP server enforcement)

## How it works

New `tool_guidance.py` module defines tool groups with trust levels and usage guidance. The `_build_system_prompt()` method calls `build_tool_guidance(trust_level)` to dynamically generate the vault tools section, inserting only the groups appropriate for the session's trust level.

## Test plan

- [x] 12 new unit tests for tool guidance builder (all passing)
- [x] Verify `build_tool_guidance("sandboxed")` includes brain read tools but excludes `brain_query`/`brain_execute`
- [x] Verify `build_tool_guidance("direct")` includes all tool groups
- [x] Existing test suite passes (485/494 — 9 pre-existing failures in `test_daily_module.py`)
- [ ] Manual: start a sandboxed chat session and verify agent can discover and use `search_memory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)