### PR TITLE
fix(app): add build duration note to deploy script

### DIFF
--- a/app/scripts/deploy.sh
+++ b/app/scripts/deploy.sh
@@ -91,7 +91,9 @@ APK_PATH="build/app/outputs/flutter-apk/app-${FLAVOR}-${BUILD_TYPE}.apk"
 # Build if needed
 if [[ "$SKIP_BUILD" == false ]]; then
     echo "Building $FLAVOR $BUILD_TYPE APK..."
+    echo "(First build or after dependency changes may take 5-10 minutes)"
     flutter build apk --$BUILD_TYPE --flavor $FLAVOR
+    echo "Build complete."
 fi
 
 # Check APK exists


### PR DESCRIPTION
## Summary

- Add progress message before `flutter build apk` noting first builds may take 5-10 minutes
- Add "Build complete" confirmation after build finishes

The deploy script itself has no timeout — the original issue was about Claude Code's Bash tool hitting its 2-minute default when running the script. This note makes it clear the build is expected to take a while.

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)