### PR TITLE
feat(computer): scope MCP tool visibility per session type

### DIFF
--- a/computer/parachute/api/mcp_tools.py
+++ b/computer/parachute/api/mcp_tools.py
@@ -42,16 +42,16 @@ logger = logging.getLogger(__name__)
 # None = all tools visible (backwards-compatible).
 # Agents can override via config later (#319).
 
-CHAT_TOOLS = {
+CHAT_TOOLS = frozenset({
     "search_memory", "search_chats", "list_chats",
-    "get_chat", "get_exchange", "list_notes", "write_note",
-}
+    "get_chat", "get_exchange", "list_notes",
+})
 
-DAILY_TOOLS = {
+DAILY_TOOLS = frozenset({
     "read_brain_entity",
     "write_card",
     "search_memory", "list_notes", "get_exchange",
-}
+})
 
 
 def _get_graph():
@@ -103,6 +103,11 @@ TOOLS = [
         },
     ),
 ] + VAULT_TOOLS  # Shared vault tools (search_memory, search_chats, list_chats, list_notes, get_chat, get_exchange)
+
+# Validate profiles reference real tool names (catches renames at import time)
+_ALL_TOOL_NAMES = frozenset(t.name for t in TOOLS)
+assert CHAT_TOOLS <= _ALL_TOOL_NAMES, f"CHAT_TOOLS has unknown tools: {CHAT_TOOLS - _ALL_TOOL_NAMES}"
+assert DAILY_TOOLS <= _ALL_TOOL_NAMES, f"DAILY_TOOLS has unknown tools: {DAILY_TOOLS - _ALL_TOOL_NAMES}"
 
 
 # ── Tool Handlers ─────────────────────────────────────────────────────────────
@@ -283,8 +288,7 @@ def register_tools(server: Server) -> None:
         ctx = get_sandbox_context()
         if ctx is None or ctx.allowed_tools is None:
             return TOOLS  # No filtering (direct sessions, or no context)
-        allowed = set(ctx.allowed_tools)
-        return [t for t in TOOLS if t.name in allowed]
+        return [t for t in TOOLS if t.name in ctx.allowed_tools]
 
     @server.call_tool()
     async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:

--- a/computer/parachute/core/daily_agent.py
+++ b/computer/parachute/core/daily_agent.py
@@ -452,7 +452,7 @@ async def _run_sandboxed(
         trust_level="sandboxed",
         agent_name=agent_name,
         allowed_writes=["write_output", "write_card"],
-        allowed_tools=list(DAILY_TOOLS),
+        allowed_tools=DAILY_TOOLS,
     )
     sandbox_token = token_store.create_token(token_ctx)
 

--- a/computer/parachute/core/orchestrator.py
+++ b/computer/parachute/core/orchestrator.py
@@ -1616,7 +1616,7 @@ class Orchestrator:
                     trust_level="sandboxed",
                     agent_name=None,  # Chat sessions, not callers
                     allowed_writes=[],  # Read-only for chat sessions
-                    allowed_tools=list(CHAT_TOOLS),
+                    allowed_tools=CHAT_TOOLS,
                 )
                 sandbox_token = token_store.create_token(token_ctx)
                 sandbox_mcps["parachute"] = build_http_mcp_config(sandbox_token)

--- a/computer/parachute/lib/sandbox_tokens.py
+++ b/computer/parachute/lib/sandbox_tokens.py
@@ -26,7 +26,7 @@ class SandboxTokenContext:
     trust_level: str  # "sandboxed"
     agent_name: str | None = None  # For callers
     allowed_writes: list[str] = field(default_factory=list)
-    allowed_tools: list[str] | None = None  # None = all tools visible
+    allowed_tools: frozenset[str] | None = None  # None = all tools visible
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
 

--- a/computer/tests/unit/test_mcp_bridge.py
+++ b/computer/tests/unit/test_mcp_bridge.py
@@ -142,17 +142,6 @@ class TestMcpBridge:
 class TestToolFiltering:
     """Tests for scoped tool visibility based on allowed_tools."""
 
-    def _list_tools_via_handler(self, server):
-        """Invoke the registered list_tools handler via MCP request dispatch."""
-        import asyncio
-        from mcp.types import ListToolsRequest
-
-        handler = server.request_handlers[ListToolsRequest]
-        result = asyncio.get_event_loop().run_until_complete(
-            handler(ListToolsRequest(method="tools/list"))
-        )
-        return result.root.tools
-
     @pytest.mark.asyncio
     async def test_list_tools_no_context_returns_all(self):
         """With no sandbox context, all tools are returned."""
@@ -166,30 +155,6 @@ class TestToolFiltering:
 
         handler = server.request_handlers[ListToolsRequest]
         reset = _current_sandbox_ctx.set(None)
-        try:
-            result = await handler(ListToolsRequest(method="tools/list"))
-            assert len(result.root.tools) == len(TOOLS)
-        finally:
-            _current_sandbox_ctx.reset(reset)
-
-    @pytest.mark.asyncio
-    async def test_list_tools_allowed_none_returns_all(self):
-        """With allowed_tools=None, all tools are returned."""
-        from parachute.api.mcp_tools import TOOLS, register_tools
-        from parachute.api.mcp_bridge import _current_sandbox_ctx
-        from mcp.server import Server
-        from mcp.types import ListToolsRequest
-
-        server = Server("test")
-        register_tools(server)
-        handler = server.request_handlers[ListToolsRequest]
-
-        ctx = SandboxTokenContext(
-            session_id="test",
-            trust_level="sandboxed",
-            allowed_tools=None,
-        )
-        reset = _current_sandbox_ctx.set(ctx)
         try:
             result = await handler(ListToolsRequest(method="tools/list"))
             assert len(result.root.tools) == len(TOOLS)
@@ -211,7 +176,7 @@ class TestToolFiltering:
         ctx = SandboxTokenContext(
             session_id="test",
             trust_level="sandboxed",
-            allowed_tools=["search_memory", "list_notes"],
+            allowed_tools=frozenset({"search_memory", "list_notes"}),
         )
         reset = _current_sandbox_ctx.set(ctx)
         try:
@@ -221,16 +186,21 @@ class TestToolFiltering:
         finally:
             _current_sandbox_ctx.reset(reset)
 
-    def test_chat_tools_profile_excludes_write_card(self):
-        """CHAT_TOOLS profile does not include write_card or read_brain_entity."""
+    def test_chat_tools_profile_exact_membership(self):
+        """CHAT_TOOLS contains exactly the expected read-only vault tools."""
         from parachute.api.mcp_tools import CHAT_TOOLS
-        assert "write_card" not in CHAT_TOOLS
-        assert "read_brain_entity" not in CHAT_TOOLS
+        assert CHAT_TOOLS == {
+            "search_memory", "search_chats", "list_chats",
+            "get_chat", "get_exchange", "list_notes",
+        }
 
-    def test_daily_tools_profile_includes_write_card(self):
-        """DAILY_TOOLS profile includes write_card."""
+    def test_daily_tools_profile_exact_membership(self):
+        """DAILY_TOOLS contains exactly the expected daily agent tools."""
         from parachute.api.mcp_tools import DAILY_TOOLS
-        assert "write_card" in DAILY_TOOLS
+        assert DAILY_TOOLS == {
+            "read_brain_entity", "write_card",
+            "search_memory", "list_notes", "get_exchange",
+        }
 
     @pytest.mark.asyncio
     async def test_call_tool_rejected_when_not_in_allowed(self):
@@ -247,7 +217,7 @@ class TestToolFiltering:
         ctx = SandboxTokenContext(
             session_id="test",
             trust_level="sandboxed",
-            allowed_tools=["search_memory"],
+            allowed_tools=frozenset({"search_memory"}),
         )
         reset = _current_sandbox_ctx.set(ctx)
         try:


### PR DESCRIPTION
## Summary

- Sandboxed chat sessions now only see read-only vault tools (no `write_card`, `read_brain_entity`, or `write_note`)
- Daily agent sessions see their focused tool set (read journals + write card)
- Defense-in-depth: `call_tool()` also rejects calls to unlisted tools
- Import-time validation catches phantom tool names if tools are ever renamed

Closes #318

## What changed

| File | Change |
|------|--------|
| `sandbox_tokens.py` | Added `allowed_tools: frozenset[str] \| None` field |
| `mcp_tools.py` | Filter `list_tools()` + `call_tool()`, define `CHAT_TOOLS` / `DAILY_TOOLS` profiles, import-time validation |
| `orchestrator.py` | Pass `allowed_tools=CHAT_TOOLS` for sandbox chat sessions |
| `daily_agent.py` | Pass `allowed_tools=DAILY_TOOLS` for daily agent sessions |
| `test_mcp_bridge.py` | Tool filtering tests, exact profile membership assertions |

## Security note

`write_note` was removed from `CHAT_TOOLS` — sandbox chats have `allowed_writes=[]` but the vault tool dispatch path had no write gate, so `write_note` with `note_type='context'` could overwrite persistent context notes injected into every future session. Tracked longer-term suggested edits pattern in #325.

## Test plan

- [x] All 19 MCP bridge tests pass
- [x] Full test suite passes
- [ ] Manual: start sandbox chat → verify `write_card` not in tool list
- [ ] Manual: run daily reflection → verify `write_card` IS in tool list

🤖 Generated with [Claude Code](https://claude.com/claude-code)