### PR TITLE
fix(sandbox): second message fails with Session ID already in use

### DIFF
--- a/computer/parachute/core/orchestrator.py
+++ b/computer/parachute/core/orchestrator.py
@@ -678,9 +678,24 @@ class Orchestrator:
             # Determine resume session ID
             # Only resume if: session exists in DB, not new, not forced fresh,
             # and SDK actually has a JSONL transcript for this session.
+            #
+            # For sandboxed sessions: skip the host-side transcript check.
+            # Sandbox transcripts live inside the container (bind-mounted from
+            # vault/.parachute/sandbox/envs/<slug>/home/.claude/), not on the
+            # host's ~/.claude/. The sandbox entrypoint handles its own resume
+            # via --resume flag passed by _run_sandboxed().
             resume_id = None
+            is_sandboxed = caps.effective_trust == "sandboxed"
             if session.id != "pending" and not is_new and not force_new:
-                if self.session_manager._check_sdk_session_exists(
+                if is_sandboxed:
+                    # Sandboxed sessions always attempt resume inside the
+                    # container — don't flip is_new based on host transcript.
+                    # _run_sandboxed() sets resume_session_id independently.
+                    logger.info(
+                        f"Sandboxed session {session.id[:8]} — skipping host "
+                        f"transcript check, container handles resume"
+                    )
+                elif self.session_manager._check_sdk_session_exists(
                     session.id, session.working_directory
                 ):
                     resume_id = session.id
@@ -1677,6 +1692,8 @@ class Orchestrator:
             session_source=session.source,
             timeout_seconds=self.settings.sandbox_timeout,
             readline_timeout=self.settings.sandbox_readline_timeout,
+            tools=PARACHUTE_TOOLS,
+            disallowed_tools=PARACHUTE_DISALLOWED_TOOLS,
         )
 
         # Three-tier resume strategy: SDK resume → history injection → fresh start
@@ -1805,6 +1822,7 @@ class Orchestrator:
                     config=sandbox_config,
                     message=retry_message,
                     container_slug=session.container_id,
+                    fresh_session=True,  # Skip --session-id to avoid transcript conflict
                 )
                 async for event in retry_stream:
                     if interrupt and interrupt.is_interrupted:

--- a/computer/parachute/core/sandbox.py
+++ b/computer/parachute/core/sandbox.py
@@ -72,6 +72,8 @@ class AgentSandboxConfig:
     system_prompt: str | None = None  # System prompt to pass to SDK inside container
     use_preset: bool = True  # Whether to wrap system_prompt in claude_code preset
     session_source: SessionSource | None = None  # Used to gate credential injection
+    tools: list[str] | None = None  # Explicit tool allow-list (passed to SDK)
+    disallowed_tools: list[str] | None = None  # Tool block-list (passed to SDK)
 
 
 class DockerSandbox:
@@ -377,6 +379,12 @@ class DockerSandbox:
         if config.agents:
             capabilities["agents"] = config.agents
 
+        # Tool filtering: pass through to entrypoint via capabilities JSON
+        if config.tools is not None:
+            capabilities["tools"] = config.tools
+        if config.disallowed_tools is not None:
+            capabilities["disallowed_tools"] = config.disallowed_tools
+
         if capabilities:
             fd2, caps_file_path = tempfile.mkstemp(
                 suffix='.json', prefix='parachute-caps-', dir=run_dir
@@ -634,12 +642,17 @@ class DockerSandbox:
         message: str,
         resume_session_id: str | None = None,
         container_slug: str | None = None,
+        fresh_session: bool = False,
     ) -> AsyncGenerator[dict, None]:
         """Run an agent session in a container, yielding streaming events.
 
         container_slug must be set by the caller. The orchestrator auto-creates
         a container record before calling this method, so it is always set for
         sandboxed sessions.
+
+        Args:
+            fresh_session: If True, tells entrypoint to skip --session-id
+                (used on retry after resume failure to avoid transcript conflict)
         """
         if not container_slug:
             raise ValueError(
@@ -651,7 +664,8 @@ class DockerSandbox:
         target = await self.ensure_container(container_slug, config)
 
         async for event in self._run_in_container(
-            target, config, message, resume_session_id, "sandbox"
+            target, config, message, resume_session_id, "sandbox",
+            fresh_session=fresh_session,
         ):
             yield event
 
@@ -793,6 +807,7 @@ class DockerSandbox:
         message: str,
         resume_session_id: str | None,
         label: str,
+        fresh_session: bool = False,
     ) -> AsyncGenerator[dict, None]:
         """Execute an agent session in a running container via docker exec.
 
@@ -805,6 +820,8 @@ class DockerSandbox:
             message: User message to send
             resume_session_id: Optional SDK session ID to resume
             label: Label for logging (e.g., "persistent sandbox", "default sandbox")
+            fresh_session: If True, tells entrypoint to skip --session-id
+                (used on retry after resume failure to avoid transcript conflict)
         """
         # Build exec args — env vars for non-sensitive config only
         exec_args = [
@@ -849,6 +866,12 @@ class DockerSandbox:
                 stdin_payload["use_preset"] = False
             if resume_session_id:
                 stdin_payload["resume_session_id"] = resume_session_id
+            if fresh_session:
+                stdin_payload["fresh_session"] = True
+            if config.tools is not None:
+                stdin_payload["tools"] = config.tools
+            if config.disallowed_tools is not None:
+                stdin_payload["disallowed_tools"] = config.disallowed_tools
 
             # Pass broker secret via stdin (not -e flag) to avoid
             # exposure in docker events / process table

--- a/computer/parachute/docker/entrypoint.py
+++ b/computer/parachute/docker/entrypoint.py
@@ -49,7 +49,28 @@ def _patch_sdk_parse_message() -> None:
 _patch_sdk_parse_message()
 
 
-async def run_query_and_emit(message: str, options) -> str | None:
+async def _keep_stdin_open(message: str, done_event: asyncio.Event):
+    """Yield a user message then block until done_event is set.
+
+    The SDK's query() with a string prompt calls end_input() immediately,
+    closing stdin.  The CLI subprocess needs stdin open for its internal tool
+    execution loop (reading permission responses, processing tool results).
+    Without this wrapper, the CLI crashes with exit code 1 on any turn that
+    involves tool use — including session resume.
+
+    Mirrors the _string_to_async_iterable() pattern from claude_sdk.py.
+    """
+    yield {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": message,
+        }
+    }
+    await done_event.wait()
+
+
+async def run_query_and_emit(message: str, options, done_event: asyncio.Event) -> str | None:
     """Run SDK query, emit JSONL events to stdout. Returns captured session ID."""
     from claude_agent_sdk import query
 
@@ -57,7 +78,9 @@ async def run_query_and_emit(message: str, options) -> str | None:
     captured_session_id = None
     captured_model = None
 
-    async for event in query(prompt=message, options=options):
+    prompt_iterable = _keep_stdin_open(message, done_event)
+
+    async for event in query(prompt=prompt_iterable, options=options):
         # Raw dicts come from patched parse_message (unknown event types)
         if isinstance(event, dict):
             continue  # Skip unknown events (rate_limit_event, etc.)
@@ -132,9 +155,13 @@ async def run_query_and_emit(message: str, options) -> str | None:
             sid = getattr(event, "session_id", None)
             if sid:
                 captured_session_id = sid
+            # Signal the stdin wrapper to close — CLI is done with this turn
+            done_event.set()
 
         # Silently ignore other SDK event types (RateLimitEvent, UsageEvent, etc.)
 
+    # Ensure stdin closes even if ResultMessage was not received
+    done_event.set()
     return captured_session_id
 
 
@@ -213,6 +240,11 @@ async def run():
     elif os.path.isdir("/home/sandbox"):
         os.chdir("/home/sandbox")
 
+    # Prevent the CLI from detecting a "nested session" and refusing to start.
+    # Each docker exec is an independent process — CLAUDECODE should never be set,
+    # but clear it defensively (mirrors claude_sdk.py's direct path).
+    os.environ.pop("CLAUDECODE", None)
+
     if not oauth_token:
         emit({"type": "error", "error": "CLAUDE_CODE_OAUTH_TOKEN not set"})
         sys.exit(1)
@@ -241,7 +273,7 @@ async def run():
         # is not fully mounted in sandboxed sessions, so no vault-wide leakage.
         options_kwargs: dict = {
             "permission_mode": "bypassPermissions",
-            "env": {"CLAUDE_CODE_OAUTH_TOKEN": oauth_token},
+            "env": {"CLAUDE_CODE_OAUTH_TOKEN": oauth_token, "CLAUDECODE": ""},
             "cwd": effective_cwd,
             "setting_sources": ["project"],
         }
@@ -272,6 +304,19 @@ async def run():
             else:
                 options_kwargs["system_prompt"] = system_prompt
 
+        # Tool filtering: control which built-in CLI tools are available.
+        # Without this, sandbox sessions get the full Claude Code tool set
+        # (including AskUserQuestion, EnterPlanMode, etc.) which are not
+        # appropriate for non-interactive container execution.
+        # Persistent mode: tools come via stdin payload.
+        # Ephemeral mode: tools come via capabilities JSON.
+        tools = request.get("tools") or capabilities.get("tools")
+        if tools:
+            options_kwargs["tools"] = tools
+        disallowed_tools = request.get("disallowed_tools") or capabilities.get("disallowed_tools")
+        if disallowed_tools:
+            options_kwargs["disallowed_tools"] = disallowed_tools
+
         # Pass capabilities to SDK if available
         if capabilities.get("mcp_servers"):
             options_kwargs["mcp_servers"] = capabilities["mcp_servers"]
@@ -301,22 +346,35 @@ async def run():
         # Non-UUID session IDs (e.g. slug-format "agent-daily-reflection") are used
         # only for container identification, not transcript naming.
         # Skip when resuming — CLI rejects --session-id + --resume.
-        if session_id and not resume_id and re.match(
+        # Also skip when fresh_session is set (retry after resume failure) — the
+        # CLI would reject a --session-id that already has a transcript.
+        fresh_session = request.get("fresh_session", False)
+        if session_id and not resume_id and not fresh_session and re.match(
             r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
             session_id, re.IGNORECASE,
         ):
             options_kwargs.setdefault("extra_args", {})["session-id"] = session_id
 
         options = ClaudeAgentOptions(**options_kwargs)
+        done_event = asyncio.Event()
 
         try:
-            captured_session_id = await run_query_and_emit(message, options)
+            captured_session_id = await run_query_and_emit(message, options, done_event)
             emit({"type": "done", "sessionId": captured_session_id or ""})
         except Exception as e:
             if resume_id:
                 # Resume failed — emit structured event so orchestrator can retry
-                # with history injection instead of dropping to zero context
-                emit({"type": "resume_failed", "error": str(e), "session_id": resume_id})
+                # with history injection instead of dropping to zero context.
+                # Extract real error from ProcessError if available.
+                if hasattr(e, "stderr") and e.stderr:
+                    resume_error = e.stderr.strip()
+                else:
+                    resume_error = str(e)
+                emit({
+                    "type": "resume_failed",
+                    "error": resume_error,
+                    "session_id": resume_id,
+                })
                 emit({"type": "done", "sessionId": session_id or ""})
                 sys.exit(0)  # Clean exit — orchestrator handles retry
             else:
@@ -331,11 +389,17 @@ async def run():
         # (e.g. "Invalid session ID") — surface it instead of the generic wrapper.
         if hasattr(e, "stderr") and e.stderr:
             error_detail = e.stderr.strip()
+        elif hasattr(e, "returncode") and hasattr(e, "stdout"):
+            # ProcessError with returncode but no stderr — include exit code
+            error_detail = f"CLI exited {e.returncode}: {e}"
         elif hasattr(e, "__cause__") and e.__cause__:
             error_detail = f"{e} (cause: {e.__cause__})"
         else:
             error_detail = str(e)
         emit({"type": "error", "error": error_detail})
+        # Also write to stderr so the orchestrator's _stream_process can
+        # capture it when the process exit code is non-zero
+        print(f"ENTRYPOINT_ERROR: {error_detail}", file=sys.stderr, flush=True)
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary
- **Root cause**: Host-side transcript check (`_check_sdk_session_exists`) incorrectly flipped `is_new=True` for sandbox sessions because transcripts live inside the container (bind-mounted from `vault/.parachute/sandbox/envs/<slug>/home/.claude/`), not on the host's `~/.claude/`. This prevented `--resume` from being passed, causing the CLI to reject the reused `--session-id`.
- Skip host transcript check for sandboxed sessions — they handle resume independently inside the container
- Keep stdin open via `_keep_stdin_open()` AsyncGenerator wrapper so the CLI's internal tool loop completes (mirrors `claude_sdk.py`'s direct path pattern)
- Clear `CLAUDECODE` env var defensively in entrypoint
- Pass `fresh_session` flag on retry after `resume_failed` to avoid `--session-id` conflict
- Better error extraction from SDK `ProcessError`
- Plumb `tools`/`disallowed_tools` through to sandbox entrypoint (partial progress on #332)

## Test plan
- [x] Direct entrypoint test: resume works with real token (2nd and 3rd messages)
- [x] API test: first sandbox message creates session and responds
- [x] API test: second sandbox message resumes correctly after orchestrator fix
- [x] Tool filtering confirmed passing through to entrypoint (debug output verified `tools` and `disallowed_tools` in SDK options)
- [x] Unit tests pass (42 sandbox tests)
- [ ] Manual: rebuild image (`docker build -t parachute-sandbox:latest -f parachute/docker/Dockerfile.sandbox parachute/docker/`), restart server, send 2+ messages to sandbox chat

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)