### PR TITLE
fix(sandbox): align tool guidance with MCP bridge filtering

### DIFF
--- a/computer/parachute/core/orchestrator.py
+++ b/computer/parachute/core/orchestrator.py
@@ -141,8 +141,9 @@ or claim to remember things not in the vault. The vault is the source of truth.
 continue without vault context rather than retrying repeatedly.
 
 **Updating context:** When the user says "remember" something about themselves
-(preferences, location, current focus), use write_note with note_type='context'
-to save it. Context notes are automatically loaded into every session.
+(preferences, location, current focus), use the write_note tool (if available)
+with note_type='context' to save it. Context notes are automatically loaded
+into every session.
 
 ## Tool Usage
 
@@ -622,7 +623,19 @@ class Orchestrator:
 
         try:
             # Phase 2: Capability discovery
-            caps = await self._discover_capabilities(agent, session, trust_level)
+            # For sandboxed sessions, pass the MCP tool profile so tool guidance
+            # only documents tools the session can actually call (not all
+            # trust-compatible tools). Direct sessions see everything.
+            sandbox_tool_profile: frozenset[str] | None = None
+            if trust_level == "sandboxed" or (
+                session.trust_level and session.trust_level == "sandboxed"
+            ):
+                from parachute.api.mcp_tools import CHAT_TOOLS
+                sandbox_tool_profile = CHAT_TOOLS
+
+            caps = await self._discover_capabilities(
+                agent, session, trust_level, allowed_tools=sandbox_tool_profile
+            )
 
             # Inject trust-filtered tool guidance into the prompt
             # (skipped for custom/agent prompts — those manage their own tool docs)
@@ -898,6 +911,7 @@ class Orchestrator:
         agent: Any,
         session: Any,
         trust_level: Optional[str],
+        allowed_tools: frozenset[str] | None = None,
     ) -> CapabilityBundle:
         """Discover and filter all capabilities (MCPs, skills, plugins, trust level).
 
@@ -1020,7 +1034,7 @@ class Orchestrator:
             plugin_dirs=plugin_dirs,
             agents_dict=agents_dict,
             effective_trust=effective_trust,
-            tool_guidance=build_tool_guidance(effective_trust),
+            tool_guidance=build_tool_guidance(effective_trust, allowed_tools=allowed_tools),
             warnings=warnings,
         )
 

--- a/computer/parachute/core/tool_guidance.py
+++ b/computer/parachute/core/tool_guidance.py
@@ -172,15 +172,23 @@ TOOL_GROUPS: list[ToolGroup] = [
 ]
 
 
-def build_tool_guidance(trust_level: str) -> str:
-    """Build a markdown section documenting available MCP tools for the given trust level.
+def build_tool_guidance(
+    trust_level: str,
+    allowed_tools: frozenset[str] | None = None,
+) -> str:
+    """Build a markdown section documenting available MCP tools.
 
-    Filters TOOL_GROUPS to include only groups whose trust level is compatible
-    with the session's trust level, then formats them as a readable markdown
-    section with usage guidance.
+    Applies two filters:
+    1. Trust level — groups whose trust level is compatible with the session's.
+    2. Allowed tools — if provided (sandbox sessions), only tools in this set
+       are included. This aligns prompt guidance with the actual MCP bridge
+       filtering (CHAT_TOOLS, DAILY_TOOLS, etc.) so the model doesn't
+       hallucinate access to tools it can't call.
 
     Args:
         trust_level: The session's effective trust level ("direct" or "sandboxed").
+        allowed_tools: Optional frozenset of tool names the session can actually
+            call. None means all trust-compatible tools are shown (direct sessions).
 
     Returns:
         Formatted markdown string, or empty string if no tools match.
@@ -195,10 +203,21 @@ def build_tool_guidance(trust_level: str) -> str:
         # Same logic as capability_filter: group is available if its trust level
         # is at least as restrictive as the session's trust level
         if group_order >= session_order:
+            # Filter individual tools by allowed set (sandbox profiles)
+            if allowed_tools is not None:
+                visible_tools = [
+                    t for t in group["tools"] if t["name"] in allowed_tools
+                ]
+            else:
+                visible_tools = group["tools"]
+
+            if not visible_tools:
+                continue  # Skip group entirely if no tools survive filtering
+
             lines = [f"### {group['name']}"]
             lines.append(group["guidance"])
             lines.append("")
-            for tool in group["tools"]:
+            for tool in visible_tools:
                 lines.append(f"- **mcp__parachute__{tool['name']}** — {tool['description']}")
             sections.append("\n".join(lines))
 

--- a/computer/tests/unit/test_tool_guidance.py
+++ b/computer/tests/unit/test_tool_guidance.py
@@ -130,3 +130,64 @@ class TestBuildToolGuidance:
             if group["trust"] == "direct":
                 assert group["name"] in direct
                 assert group["name"] not in sandboxed
+
+
+class TestAllowedToolsFiltering:
+    """Tests for allowed_tools parameter (sandbox tool profiles)."""
+
+    def test_allowed_tools_filters_individual_tools(self):
+        """When allowed_tools is set, only those tools appear in guidance."""
+        from parachute.api.mcp_tools import CHAT_TOOLS
+
+        result = build_tool_guidance("sandboxed", allowed_tools=CHAT_TOOLS)
+        # CHAT_TOOLS should be present
+        assert "search_memory" in result
+        assert "list_chats" in result
+        assert "get_chat" in result
+        assert "get_exchange" in result
+        assert "list_notes" in result
+        assert "search_chats" in result
+
+    def test_allowed_tools_excludes_non_chat_tools(self):
+        """Sandbox chat sessions should not see write_note, get_session, etc."""
+        from parachute.api.mcp_tools import CHAT_TOOLS
+
+        result = build_tool_guidance("sandboxed", allowed_tools=CHAT_TOOLS)
+        assert "write_note" not in result
+        assert "brain_schema" not in result
+        assert "get_session" not in result
+        assert "create_session" not in result
+        assert "search_by_tag" not in result
+        assert "list_tags" not in result
+        assert "add_session_tag" not in result
+        assert "remove_session_tag" not in result
+
+    def test_allowed_tools_drops_empty_groups(self):
+        """Groups with no surviving tools should not appear at all."""
+        from parachute.api.mcp_tools import CHAT_TOOLS
+
+        result = build_tool_guidance("sandboxed", allowed_tools=CHAT_TOOLS)
+        # Sessions & Tags group has no tools in CHAT_TOOLS
+        assert "Sessions & Tags" not in result
+        # Multi-Agent group has no tools in CHAT_TOOLS
+        assert "Multi-Agent" not in result
+
+    def test_none_allowed_tools_shows_all(self):
+        """None means no filtering (backwards compatible, direct sessions)."""
+        full = build_tool_guidance("sandboxed")
+        explicit_none = build_tool_guidance("sandboxed", allowed_tools=None)
+        assert full == explicit_none
+
+    def test_daily_tools_profile(self):
+        """DAILY_TOOLS should show its specific tool set."""
+        from parachute.api.mcp_tools import DAILY_TOOLS
+
+        result = build_tool_guidance("sandboxed", allowed_tools=DAILY_TOOLS)
+        assert "search_memory" in result
+        assert "list_notes" in result
+        assert "get_exchange" in result
+        # Daily-specific tools are in DAILY_TOOLS but not in TOOL_GROUPS
+        # (read_brain_entity, write_card are bridge-only, not in guidance)
+        # write_note should NOT be present
+        assert "write_note" not in result
+        assert "create_session" not in result


### PR DESCRIPTION
## Summary
- **Root cause**: System prompt's tool guidance documented all trust-compatible MCP tools (16 tools) but the MCP bridge only exposed `CHAT_TOOLS` (6 tools). The model saw tools like `write_note`, `get_session`, `create_session`, `brain_schema`, and tag management tools in its instructions and listed them as available — even though the bridge would reject calls to them.
- **Fix**: Added `allowed_tools` parameter to `build_tool_guidance()` so sandbox sessions only see tools matching their actual MCP profile (`CHAT_TOOLS`/`DAILY_TOOLS`). Threaded through `_discover_capabilities` → `CapabilityBundle` → prompt injection.
- Made `write_note` mention in `PARACHUTE_PROMPT` conditional ("if available") since it's not available in sandbox sessions.
- Added 5 tests covering CHAT_TOOLS filtering, DAILY_TOOLS filtering, empty group dropping, and backwards compatibility.

Closes #332

## Test plan
- [x] All 17 tool guidance tests pass (12 existing + 5 new)
- [x] All 53 related unit tests pass (tool guidance + orchestrator + MCP)
- [ ] Manual: start a sandbox chat session, ask "what tools do you have" — should only list 6 vault tools (search_memory, search_chats, list_chats, get_chat, get_exchange, list_notes)
- [ ] Manual: start a direct session — should still see all tools including write_note, brain_schema, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)