### PR TITLE
Wire journal entry tags to graph via TagService

### DIFF
--- a/app/lib/features/daily/journal/screens/journal_screen.dart
+++ b/app/lib/features/daily/journal/screens/journal_screen.dart
@@ -13,6 +13,7 @@ import 'package:parachute/core/providers/app_state_provider.dart' show apiKeyPro
 import 'package:parachute/core/providers/feature_flags_provider.dart' show aiServerUrlProvider;
 import 'package:parachute/core/providers/sync_provider.dart';
 import 'package:parachute/core/providers/connectivity_provider.dart' show isServerAvailableProvider;
+import 'package:parachute/core/services/tag_service.dart' show tagServiceProvider;
 import '../../recorder/providers/service_providers.dart';
 import '../models/entry_metadata.dart' show TranscriptionStatus;
 import '../models/journal_day.dart';
@@ -1439,7 +1440,7 @@ ref.read(journalScreenStateProvider.notifier).completeTranscription(entry.id);
 
   // ========== Entry Detail and Actions ==========
 
-  void _showEntryDetail(BuildContext context, JournalEntry entry) {
+  Future<void> _showEntryDetail(BuildContext context, JournalEntry entry) async {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final canEdit = entry.id != 'preamble' && !entry.id.startsWith('plain_');
 
@@ -1449,14 +1450,41 @@ ref.read(journalScreenStateProvider.notifier).completeTranscription(entry.id);
       return;
     }
 
+    // Fetch tags from graph and system-wide tag list when online
+    var displayEntry = entry;
+    var allTags = <String>[];
+    final isOnline = ref.read(isServerAvailableProvider);
+    if (isOnline) {
+      final tagService = ref.read(tagServiceProvider);
+      try {
+        final results = await Future.wait([
+          tagService.getEntityTags('note', entry.id),
+          tagService.listTags(),
+        ]);
+        final graphTags = results[0] as List<String>;
+        final tagInfos = results[1] as List;
+        // Use graph tags as source of truth when online; keep metadata
+        // tags if graph has no record yet (entry not yet migrated).
+        if (graphTags.isNotEmpty) {
+          displayEntry = entry.copyWith(tags: graphTags);
+        }
+        allTags = tagInfos.map((t) => (t as dynamic).tag as String).toList();
+      } catch (_) {
+        // Fall back to metadata tags on error
+      }
+    }
+
+    if (!context.mounted) return;
+
     // Voice/photo/handwriting entries use the existing modal
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       builder: (sheetContext) => EntryEditModal(
-        entry: entry,
+        entry: displayEntry,
         canEdit: canEdit,
+        allTags: allTags,
         audioPlayer: entry.hasAudio ? _buildAudioPlayer(context, entry, isDark) : null,
         onSave: (updatedEntry) async {
           final api = ref.read(dailyApiServiceProvider);
@@ -1470,15 +1498,36 @@ ref.read(journalScreenStateProvider.notifier).completeTranscription(entry.id);
             content: updatedEntry.content,
             metadata: metadata,
           );
+          if (!mounted) return;
           if (serverUpdated == null) {
             // Server unreachable — queue the edit for retry.
             final cache = await ref.read(journalLocalCacheProvider.future);
+            if (!mounted) return;
             cache.markForEdit(
               updatedEntry.id,
               content: updatedEntry.content,
               title: updatedEntry.title,
             );
           }
+
+          // Sync tag changes to graph — best-effort alongside metadata.
+          // Metadata is the durable path; backend migration catches gaps.
+          final oldTags = Set<String>.from(displayEntry.tags ?? []);
+          final newTags = Set<String>.from(updatedEntry.tags ?? []);
+          if (oldTags != newTags) {
+            final tagService = ref.read(tagServiceProvider);
+            for (final t in newTags.difference(oldTags)) {
+              tagService.addTag('note', updatedEntry.id, t).then((ok) {
+                if (!ok) debugPrint('[JournalScreen] Tag sync failed: add "$t" to ${updatedEntry.id}');
+              });
+            }
+            for (final t in oldTags.difference(newTags)) {
+              tagService.removeTag('note', updatedEntry.id, t).then((ok) {
+                if (!ok) debugPrint('[JournalScreen] Tag sync failed: remove "$t" from ${updatedEntry.id}');
+              });
+            }
+          }
+
           ref.invalidate(selectedJournalProvider);
         },
       ),

--- a/app/lib/features/daily/journal/widgets/entry_edit_modal.dart
+++ b/app/lib/features/daily/journal/widgets/entry_edit_modal.dart
@@ -18,6 +18,9 @@ class EntryEditModal extends StatefulWidget {
   final Future<void> Function(String audioPath)? onPlayAudio;
   final Widget? audioPlayer;
 
+  /// System-wide tags for autocomplete suggestions.
+  final List<String> allTags;
+
   const EntryEditModal({
     super.key,
     required this.entry,
@@ -26,6 +29,7 @@ class EntryEditModal extends StatefulWidget {
     this.onSave,
     this.onPlayAudio,
     this.audioPlayer,
+    this.allTags = const [],
   });
 
   @override
@@ -597,6 +601,7 @@ class _EntryEditModalState extends State<EntryEditModal>
           _hasChanges = true;
         });
       },
+      suggestions: widget.allTags,
       hintText: 'Add a tag (e.g., "recipe", "work")...',
     );
   }

--- a/docs/plans/2026-03-25-wire-journal-tags-to-graph-plan.md
+++ b/docs/plans/2026-03-25-wire-journal-tags-to-graph-plan.md
@@ -1,0 +1,111 @@
+---
+issue: 343
+title: Wire journal entry tags to graph via TagService
+created: 2026-03-25
+status: plan
+---
+
+# Wire Journal Entry Tags to Graph via TagService
+
+## Current State
+
+Tags on journal entries flow: `EntryEditModal._tags` → `JournalEntry.copyWith(tags:)` → `onSave` callback → `DailyApiService.updateEntry(metadata: {tags: [...]})` → server stores in `Note.metadata_json` → backend startup migration converts metadata tags to TAGGED_WITH graph edges.
+
+This works but is indirect — the app never talks to the graph tag system directly. The `TagService` and `tagServiceProvider` exist but are unused.
+
+## Design
+
+**Dual-write with graph as source of truth when online:**
+
+1. **On save**: continue sending tags in metadata (backward compat), AND call TagService to sync graph edges (add new, remove deleted)
+2. **On load**: when server available, fetch tags from TagService (graph) instead of metadata
+3. **Offline**: fall back to metadata tags; queue tag sync operations for when server reconnects
+
+This is incremental — no big-bang migration, no breaking changes.
+
+## Implementation
+
+### Phase 1: Sync tags to graph on save (journal_screen.dart)
+
+In the `onSave` callback (~line 1461), after the existing `api.updateEntry()` call, diff the original vs updated tags and call TagService:
+
+```dart
+onSave: (updatedEntry) async {
+  final api = ref.read(dailyApiServiceProvider);
+  // ... existing updateEntry call (keep for metadata backward compat) ...
+
+  // Sync tags to graph
+  final tagService = ref.read(tagServiceProvider);
+  final oldTags = Set<String>.from(entry.tags ?? []);
+  final newTags = Set<String>.from(updatedEntry.tags ?? []);
+  final added = newTags.difference(oldTags);
+  final removed = oldTags.difference(newTags);
+  for (final t in added) {
+    tagService.addTag('note', updatedEntry.id, t);  // fire-and-forget
+  }
+  for (final t in removed) {
+    tagService.removeTag('note', updatedEntry.id, t);  // fire-and-forget
+  }
+},
+```
+
+Fire-and-forget is fine here — the metadata write is the durable path, and the backend migration will catch any missed graph edges on next startup.
+
+**File**: `app/lib/features/daily/journal/screens/journal_screen.dart`
+
+### Phase 2: Load tags from graph when available (journal_screen.dart)
+
+Before opening `EntryEditModal`, if server is available, fetch graph tags to ensure we show the canonical set:
+
+```dart
+// Before opening modal:
+final isOnline = ref.read(isServerAvailableProvider);
+var displayEntry = entry;
+if (isOnline) {
+  final tagService = ref.read(tagServiceProvider);
+  final graphTags = await tagService.getEntityTags('note', entry.id);
+  if (graphTags.isNotEmpty || (entry.tags ?? []).isNotEmpty) {
+    displayEntry = entry.copyWith(tags: graphTags.isNotEmpty ? graphTags : null);
+  }
+}
+// Then open EntryEditModal with displayEntry
+```
+
+**File**: `app/lib/features/daily/journal/screens/journal_screen.dart`
+
+### Phase 3: TagInput autocomplete from graph (tag_input.dart)
+
+Currently `TagInput.suggestions` is passed in statically. Add optional `tagServiceProvider` lookup for autocomplete:
+
+- In `EntryEditModal._buildTagPicker`, pass `allTags` fetched from `tagService.listTags()` as suggestions
+- This makes the autocomplete show all tags used across the system, not just locally known ones
+
+**Files**: `app/lib/features/daily/journal/widgets/entry_edit_modal.dart`
+
+### What we're NOT doing
+
+- **No separate tag queue**: Tag sync is fire-and-forget alongside the existing metadata save. Backend migration handles gaps. Building a separate PendingTagQueue would be over-engineering given the migration safety net.
+- **No removing metadata tags**: Keep tags in metadata for offline fallback. The backend migration is idempotent and handles the metadata→graph conversion.
+- **No brain entity tags**: Not using brain entities right now.
+- **No cross-entity tag browser**: Separate issue.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `app/lib/features/daily/journal/screens/journal_screen.dart` | Import tagServiceProvider, add graph sync in onSave, fetch graph tags before modal |
+| `app/lib/features/daily/journal/widgets/entry_edit_modal.dart` | Accept and pass through allTags for autocomplete |
+| `app/lib/core/widgets/tag_input.dart` | No changes needed (already accepts suggestions) |
+
+## Acceptance Criteria
+
+- [ ] Adding/removing tags in EntryEditModal calls TagService add/remove
+- [ ] Tags loaded from graph when server available
+- [ ] Offline: tags still work via metadata fallback
+- [ ] `tagServiceProvider` is consumed (not dead code)
+- [ ] Existing entries with local tags still work (backend migration handles graph sync)
+- [ ] Autocomplete shows system-wide tags from graph
+
+## Risk
+
+**Low**. Dual-write is additive — if TagService calls fail, metadata path still works and backend migration catches up. No schema changes, no breaking API changes.


### PR DESCRIPTION
## Summary
- Load tags from graph (`TagService.getEntityTags`) when server is available, fall back to metadata tags offline
- Sync tag add/remove to graph on save via `TagService` (fire-and-forget alongside metadata write)
- Pass system-wide tag list from `TagService.listTags()` to `TagInput` autocomplete suggestions
- `tagServiceProvider` is now consumed (no longer dead code)

Dual-write approach: metadata tags remain as durable offline fallback. Backend startup migration (`_migrate_tags_to_graph`) catches any missed graph edges.

## Test plan
- [ ] Open a voice/photo entry, add a tag, save — verify tag appears on re-open
- [ ] Add a tag while server is running — verify TAGGED_WITH edge exists in graph (`curl localhost:3333/api/tags/note/{entryId}`)
- [ ] Add tags to multiple entries — verify autocomplete shows system-wide tags
- [ ] Disconnect server, add a tag — verify it saves locally, syncs to graph after reconnect (via backend migration)
- [ ] Run `flutter analyze` — only pre-existing warnings

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)