### PR TITLE
feat(auth): unified token auth — config set, API, and app paste flow

### DIFF
--- a/app/lib/features/settings/widgets/claude_auth_section.dart
+++ b/app/lib/features/settings/widgets/claude_auth_section.dart
@@ -1,14 +1,16 @@
-import 'dart:io';
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/providers/server_providers.dart';
+import 'package:parachute/core/providers/feature_flags_provider.dart';
+import 'package:parachute/core/providers/app_state_provider.dart';
 
-/// Settings section for Claude authentication (desktop only)
+/// Settings section for Claude authentication.
 ///
-/// Shows a simple button to run `claude login` for authentication.
-/// We don't try to detect auth status since Claude stores credentials
-/// in ways that aren't easily accessible.
+/// Shows token status and provides a paste flow for setting the
+/// Claude OAuth token (from `claude setup-token`).
 class ClaudeAuthSection extends ConsumerStatefulWidget {
   const ClaudeAuthSection({super.key});
 
@@ -17,64 +19,119 @@ class ClaudeAuthSection extends ConsumerStatefulWidget {
 }
 
 class _ClaudeAuthSectionState extends ConsumerState<ClaudeAuthSection> {
-  bool _isAuthenticating = false;
+  bool _isLoading = true;
+  bool _isConfigured = false;
+  String? _tokenPrefix;
   String? _message;
   bool _isError = false;
 
-  Future<void> _runClaudeLogin() async {
+  @override
+  void initState() {
+    super.initState();
+    _loadTokenStatus();
+  }
+
+  Future<void> _loadTokenStatus() async {
+    try {
+      final featureFlags = ref.read(featureFlagsServiceProvider);
+      final serverUrl = await featureFlags.getAiServerUrl();
+      final apiKey = await ref.read(apiKeyProvider.future);
+      final headers = {
+        if (apiKey != null && apiKey.isNotEmpty) 'Authorization': 'Bearer $apiKey',
+      };
+
+      final response = await http.get(
+        Uri.parse('$serverUrl/api/settings/token'),
+        headers: headers,
+      ).timeout(const Duration(seconds: 5));
+
+      if (mounted && response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        setState(() {
+          _isLoading = false;
+          _isConfigured = data['configured'] as bool? ?? false;
+          _tokenPrefix = data['prefix'] as String?;
+        });
+      } else if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      debugPrint('[ClaudeAuth] Error loading token status: $e');
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _showTokenDialog() async {
+    final controller = TextEditingController();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (context) => _TokenDialog(controller: controller),
+    );
+    controller.dispose();
+
+    if (result != null && result.isNotEmpty) {
+      await _saveToken(result);
+    }
+  }
+
+  Future<void> _saveToken(String token) async {
     setState(() {
-      _isAuthenticating = true;
       _message = null;
       _isError = false;
     });
 
     try {
-      // Find claude binary
-      final whichResult = await Process.run('which', ['claude']);
-      final claudePath = whichResult.stdout.toString().trim();
+      final featureFlags = ref.read(featureFlagsServiceProvider);
+      final serverUrl = await featureFlags.getAiServerUrl();
+      final apiKey = await ref.read(apiKeyProvider.future);
 
-      if (claudePath.isEmpty) {
-        setState(() {
-          _isAuthenticating = false;
-          _message = 'Claude CLI not found. Install it first.';
-          _isError = true;
-        });
-        return;
-      }
-
-      debugPrint('[ClaudeAuth] Running: $claudePath login');
-
-      // Run claude login - this opens a browser for OAuth
-      final process = await Process.start(
-        claudePath,
-        ['login'],
-        mode: ProcessStartMode.inheritStdio,
-      );
-
-      final exitCode = await process.exitCode;
-      debugPrint('[ClaudeAuth] login exited with code: $exitCode');
+      final response = await http.put(
+        Uri.parse('$serverUrl/api/settings/token'),
+        headers: {
+          'Content-Type': 'application/json',
+          if (apiKey != null && apiKey.isNotEmpty) 'Authorization': 'Bearer $apiKey',
+        },
+        body: jsonEncode({'token': token}),
+      ).timeout(const Duration(seconds: 5));
 
       if (mounted) {
-        setState(() {
-          _isAuthenticating = false;
-          if (exitCode == 0) {
-            _message = 'Authentication complete!';
+        if (response.statusCode == 200) {
+          setState(() {
+            _message = 'Token saved and activated.';
             _isError = false;
-          } else {
-            _message = 'Authentication may not have completed. Try again if needed.';
-            _isError = false; // Not really an error, user might have cancelled
-          }
-        });
+          });
+          await _loadTokenStatus();
+        } else {
+          final detail = _parseErrorDetail(response);
+          setState(() {
+            _message = detail;
+            _isError = true;
+          });
+        }
       }
     } catch (e) {
-      debugPrint('[ClaudeAuth] Error: $e');
+      debugPrint('[ClaudeAuth] Error saving token: $e');
       if (mounted) {
         setState(() {
-          _isAuthenticating = false;
-          _message = 'Error: $e';
+          _message = 'Failed to save token: $e';
           _isError = true;
         });
       }
+    }
+  }
+
+  String _parseErrorDetail(http.Response response) {
+    try {
+      final body = jsonDecode(response.body) as Map<String, dynamic>;
+      return body['detail'] as String? ?? 'Failed to save token (${response.statusCode})';
+    } catch (_) {
+      return 'Failed to save token (${response.statusCode})';
     }
   }
 
@@ -109,13 +166,19 @@ class _ClaudeAuthSectionState extends ConsumerState<ClaudeAuthSection> {
           ],
         ),
         SizedBox(height: Spacing.sm),
-        Text(
-          'Parachute uses Claude for AI features. Run claude login to authenticate.',
-          style: TextStyle(
-            fontSize: TypographyTokens.bodySmall,
-            color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
-          ),
-        ),
+
+        // Token status
+        if (_isLoading)
+          Text(
+            'Checking token status...',
+            style: TextStyle(
+              fontSize: TypographyTokens.bodySmall,
+              color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
+            ),
+          )
+        else
+          _buildTokenStatus(isDark),
+
         SizedBox(height: Spacing.lg),
 
         // Message display
@@ -154,24 +217,16 @@ class _ClaudeAuthSectionState extends ConsumerState<ClaudeAuthSection> {
           SizedBox(height: Spacing.lg),
         ],
 
-        // Login button
+        // Update token button
         SizedBox(
           width: double.infinity,
           child: FilledButton.icon(
-            onPressed: _isAuthenticating ? null : _runClaudeLogin,
-            icon: _isAuthenticating
-                ? SizedBox(
-                    width: 18,
-                    height: 18,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      valueColor: AlwaysStoppedAnimation<Color>(
-                        BrandColors.softWhite,
-                      ),
-                    ),
-                  )
-                : const Icon(Icons.login, size: 18),
-            label: Text(_isAuthenticating ? 'Opening browser...' : 'Run claude login'),
+            onPressed: _showTokenDialog,
+            icon: Icon(
+              _isConfigured ? Icons.refresh : Icons.vpn_key,
+              size: 18,
+            ),
+            label: Text(_isConfigured ? 'Update Token' : 'Set Token'),
             style: FilledButton.styleFrom(
               backgroundColor: isDark ? BrandColors.nightForest : BrandColors.forest,
             ),
@@ -180,11 +235,118 @@ class _ClaudeAuthSectionState extends ConsumerState<ClaudeAuthSection> {
 
         SizedBox(height: Spacing.sm),
         Text(
-          'This will open a browser window to sign in with your Anthropic account.',
+          'Run `claude setup-token` in your terminal to get a token, then paste it here.',
           style: TextStyle(
             fontSize: TypographyTokens.labelSmall,
             color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
           ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTokenStatus(bool isDark) {
+    final statusColor = _isConfigured ? BrandColors.success : BrandColors.warning;
+    final statusIcon = _isConfigured ? Icons.check_circle : Icons.warning_amber;
+    final statusText = _isConfigured
+        ? 'Token configured ($_tokenPrefix)'
+        : 'Token not configured';
+
+    return Row(
+      children: [
+        Icon(statusIcon, size: 16, color: statusColor),
+        SizedBox(width: Spacing.xs),
+        Flexible(
+          child: Text(
+            statusText,
+            style: TextStyle(
+              fontSize: TypographyTokens.bodySmall,
+              color: statusColor,
+            ),
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Dialog for pasting a Claude OAuth token.
+class _TokenDialog extends StatelessWidget {
+  final TextEditingController controller;
+
+  const _TokenDialog({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return AlertDialog(
+      title: const Text('Set Claude Token'),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Run this in your terminal:',
+              style: TextStyle(
+                fontSize: TypographyTokens.bodySmall,
+                color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
+              ),
+            ),
+            SizedBox(height: Spacing.sm),
+            Container(
+              padding: EdgeInsets.all(Spacing.sm),
+              decoration: BoxDecoration(
+                color: isDark
+                    ? BrandColors.charcoal.withValues(alpha: 0.5)
+                    : BrandColors.softWhite,
+                borderRadius: BorderRadius.circular(Radii.sm),
+              ),
+              child: SelectableText(
+                'claude setup-token',
+                style: TextStyle(
+                  fontFamily: 'monospace',
+                  fontSize: TypographyTokens.bodySmall,
+                  color: isDark ? BrandColors.nightTurquoise : BrandColors.forest,
+                ),
+              ),
+            ),
+            SizedBox(height: Spacing.lg),
+            Text(
+              'Then paste the token here:',
+              style: TextStyle(
+                fontSize: TypographyTokens.bodySmall,
+                color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
+              ),
+            ),
+            SizedBox(height: Spacing.sm),
+            TextField(
+              controller: controller,
+              obscureText: true,
+              decoration: const InputDecoration(
+                hintText: 'Paste token...',
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 1,
+              autofocus: true,
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () {
+            final token = controller.text.trim();
+            Navigator.of(context).pop(token);
+          },
+          child: const Text('Save'),
         ),
       ],
     );

--- a/computer/parachute/api/settings.py
+++ b/computer/parachute/api/settings.py
@@ -1,11 +1,16 @@
 """
-Settings endpoints — personal instructions and prompt visibility.
+Settings endpoints — personal instructions, prompt visibility, and token management.
 """
 
+import logging
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
+
+from parachute.config import PARACHUTE_DIR, _load_token, get_settings, save_token
+
+logger = logging.getLogger(__name__)
 
 # Bridge prompts removed — observe/enrich replaced by system Message writes.
 # Constants kept for API backward compat (Flutter settings screen may display them).
@@ -62,3 +67,57 @@ async def save_instructions(body: InstructionsUpdate, request: Request) -> dict:
         raise HTTPException(status_code=500, detail=f"Failed to write instructions: {e}") from e
 
     return {"ok": True, "path": "CLAUDE.md"}
+
+
+# --- Token management ---
+
+
+class TokenUpdate(BaseModel):
+    token: str
+
+
+@router.get("/settings/token")
+async def get_token_status(request: Request) -> dict:
+    """
+    Return token configuration status without exposing the full token.
+
+    Returns {"configured": bool, "prefix": "sk-ant-...abc" | null}.
+    """
+    token = _load_token(PARACHUTE_DIR)
+    if not token:
+        return {"configured": False, "prefix": None}
+    # Show first 12 + last 3 chars for identification, never the full token
+    if len(token) > 15:
+        prefix = token[:12] + "..." + token[-3:]
+    else:
+        prefix = "***"
+    return {"configured": True, "prefix": prefix}
+
+
+@router.put("/settings/token")
+async def save_token_endpoint(body: TokenUpdate, request: Request) -> dict:
+    """
+    Save a Claude OAuth token and hot-reload it in the running server.
+
+    Writes to ~/.parachute/.token (0600 permissions) and updates the
+    in-memory settings so new sessions pick up the token immediately.
+    """
+    token = body.token.strip()
+    if not token:
+        raise HTTPException(status_code=400, detail="Token cannot be empty")
+
+    save_token(PARACHUTE_DIR, token)
+
+    # Hot-reload: update in-memory settings so next stream uses the new token
+    settings = get_settings()
+    settings.claude_code_oauth_token = token
+
+    # Update sandbox's token reference if it exists
+    orchestrator = getattr(request.app.state, "orchestrator", None)
+    if orchestrator is not None:
+        sandbox = getattr(orchestrator, "_sandbox", None)
+        if sandbox is not None:
+            sandbox.claude_token = token
+
+    logger.info("Token updated via API and hot-reloaded")
+    return {"ok": True, "configured": True}

--- a/computer/parachute/cli.py
+++ b/computer/parachute/cli.py
@@ -1747,7 +1747,11 @@ def cmd_doctor(args: argparse.Namespace) -> None:
         token = _load_token(parachute_dir) or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
         if token:
             return True, f"{token[:12]}..."
-        return False, "no token found (run: parachute install)"
+        return False, (
+            "no token found\n"
+            "      Fix: Run `claude setup-token` then `parachute config set token <value>`\n"
+            "      Or: Paste in Settings > Claude Authentication"
+        )
 
     check("Claude token", check_token)
 
@@ -1887,8 +1891,12 @@ def _config_show() -> None:
 def _config_set(key: str, value: str) -> None:
     """Set a config value."""
     if key in ("token", "claude_code_oauth_token"):
-        print("Error: Use 'parachute install' to set the token, or write to .token directly.")
-        sys.exit(1)
+        parachute_dir = _get_parachute_dir()
+        save_token(parachute_dir, value)
+        masked = value[:12] + "..." if len(value) > 12 else "***"
+        print(f"Token saved to {parachute_dir / '.token'} ({masked})")
+        print("Note: Restart the server for the new token to take effect.")
+        return
 
     if key not in CONFIG_KEYS:
         print(f"Unknown key: {key}")

--- a/computer/parachute/lib/typed_errors.py
+++ b/computer/parachute/lib/typed_errors.py
@@ -112,11 +112,10 @@ ERROR_DEFINITIONS: dict[ErrorCode, dict[str, Any]] = {
         "can_retry": False,
     },
     ErrorCode.EXPIRED_TOKEN: {
-        "title": "Session Expired",
-        "message": "Your authentication session has expired.",
+        "title": "Token Expired or Invalid",
+        "message": "Your Claude token has expired or is invalid. Run `claude setup-token` in your terminal and update it in Settings.",
         "actions": [
-            RecoveryAction(key="r", label="Re-authenticate", action="reauth"),
-            RecoveryAction(key="s", label="Check settings", action="settings"),
+            RecoveryAction(key="s", label="Open Settings", action="settings"),
         ],
         "can_retry": False,
     },

--- a/computer/tests/unit/test_cli_commands.py
+++ b/computer/tests/unit/test_cli_commands.py
@@ -171,10 +171,12 @@ class TestConfigSetGet:
             with pytest.raises(SystemExit):
                 _config_set("unknown_key", "value")
 
-    def test_set_rejects_token(self, vault):
+    def test_set_saves_token(self, vault):
         with patch("parachute.cli._get_parachute_dir", return_value=vault):
-            with pytest.raises(SystemExit):
-                _config_set("token", "sk-secret")
+            _config_set("token", "sk-ant-test-token-value")
+        token_file = vault / ".token"
+        assert token_file.exists()
+        assert token_file.read_text().strip() == "sk-ant-test-token-value"
 
     def test_set_converts_port_to_int(self, vault):
         with patch("parachute.cli._get_parachute_dir", return_value=vault):

--- a/docs/plans/2026-03-25-feat-unified-token-auth-plan.md
+++ b/docs/plans/2026-03-25-feat-unified-token-auth-plan.md
@@ -1,0 +1,170 @@
+---
+title: "Unified token auth — one setup-token for sandbox and trusted sessions"
+type: feat
+date: 2026-03-25
+issue: 349
+---
+
+# Unified Token Auth
+
+Use one explicit `setup-token` everywhere — sandbox and trusted sessions alike. Fix the broken configuration paths so users can actually set the token.
+
+## Problem
+
+Sandbox sessions fail with missing `CLAUDE_CODE_OAUTH_TOKEN` because:
+1. `parachute config set token` refuses with an error (line 1889 of `cli.py`)
+2. `parachute install` is the only path and it's interactive/easy to skip
+3. App settings has "Run claude login" which doesn't produce a `.token` file
+4. No auth error feedback tells users what to do
+
+## Acceptance Criteria
+
+- [x] `parachute config set token <value>` writes `~/.parachute/.token`
+- [x] `PUT /api/settings/token` saves token and hot-reloads it in the running server
+- [x] `GET /api/settings/token` returns `{ configured: bool, prefix: "sk-ant-...abc" }` (never full token)
+- [x] App settings shows token status (configured / not configured) and a paste flow
+- [x] Auth failures emit `typed_error` with `EXPIRED_TOKEN` code and clear recovery message
+- [x] `parachute doctor` token check tells user exactly how to fix (not just "run install")
+
+## Implementation
+
+### Step 1: Fix CLI `config set token` — `computer/parachute/cli.py`
+
+**What**: Remove the guard at line 1889 that blocks `token` / `claude_code_oauth_token` keys.
+
+**Change `_config_set()`**: When key is `token` or `claude_code_oauth_token`, call `save_token(parachute_dir, value)` instead of rejecting. Print masked confirmation.
+
+```python
+def _config_set(key: str, value: str) -> None:
+    if key in ("token", "claude_code_oauth_token"):
+        parachute_dir = _get_parachute_dir()
+        save_token(parachute_dir, value)
+        masked = value[:12] + "..." if len(value) > 12 else "***"
+        print(f"Token saved to {parachute_dir / '.token'} ({masked})")
+        print("Note: Restart the server for the new token to take effect.")
+        return
+    # ... rest unchanged
+```
+
+### Step 2: Token API endpoints — `computer/parachute/api/settings.py`
+
+**What**: Add `GET /api/settings/token` and `PUT /api/settings/token`.
+
+**GET** returns `{ "configured": true, "prefix": "sk-ant-sid01-...abc" }` — first 12 chars + last 3 chars, never the full token.
+
+**PUT** accepts `{ "token": "..." }`:
+1. Validates non-empty
+2. Calls `save_token()` to write `~/.parachute/.token`
+3. Hot-reloads: calls `get_settings()` to get the singleton, sets `settings.claude_code_oauth_token = token`
+4. Updates `orchestrator._sandbox.claude_token` if sandbox exists
+5. Returns `{ "ok": true, "configured": true }`
+
+```python
+class TokenUpdate(BaseModel):
+    token: str
+
+@router.get("/settings/token")
+async def get_token_status(request: Request) -> dict:
+    token = _load_token(PARACHUTE_DIR)
+    if not token:
+        return {"configured": False, "prefix": None}
+    prefix = token[:12] + "..." + token[-3:] if len(token) > 15 else "***"
+    return {"configured": True, "prefix": prefix}
+
+@router.put("/settings/token")
+async def save_token_endpoint(body: TokenUpdate, request: Request) -> dict:
+    token = body.token.strip()
+    if not token:
+        raise HTTPException(status_code=400, detail="Token cannot be empty")
+    save_token(PARACHUTE_DIR, token)
+    # Hot-reload in running server
+    settings = get_settings()
+    settings.claude_code_oauth_token = token
+    orchestrator = request.app.state.orchestrator
+    if hasattr(orchestrator, '_sandbox'):
+        orchestrator._sandbox.claude_token = token
+    return {"ok": True, "configured": True}
+```
+
+### Step 3: App settings — `app/lib/features/settings/widgets/claude_auth_section.dart`
+
+**What**: Replace "Run claude login" with a setup-token paste flow.
+
+**UI design**:
+- Status line: green check "Token configured (sk-ant-...abc)" or yellow warning "Token not configured"
+- "Update Token" button → shows a paste dialog with:
+  - Instructions: "Run `claude setup-token` in your terminal, then paste the token here"
+  - TextField (obscured) for pasting
+  - Save button → calls `PUT /api/settings/token`
+  - Success/error feedback
+
+**Data flow**:
+- On widget init: `GET /api/settings/token` to check status
+- On save: `PUT /api/settings/token` → refresh status
+- Uses existing server connection from `ref.watch(serverConfigProvider)`
+
+### Step 4: Auth error detection — `computer/parachute/lib/typed_errors.py`
+
+**What**: Improve `EXPIRED_TOKEN` error definition to give specific recovery instructions.
+
+Update the `EXPIRED_TOKEN` entry:
+```python
+ErrorCode.EXPIRED_TOKEN: {
+    "title": "Token Expired or Invalid",
+    "message": "Your Claude token has expired or is invalid. Run `claude setup-token` in your terminal and update it in Settings.",
+    "actions": [
+        RecoveryAction(key="s", label="Open Settings", action="settings"),
+    ],
+    "can_retry": False,
+},
+```
+
+The existing `parse_error()` already detects 401/unauthorized/token/expired patterns and maps to `EXPIRED_TOKEN`. The typed error system already emits `typed_error` SSE events. The app already renders `ErrorRecoveryCard` for these. **No new wiring needed** — just better copy.
+
+### Step 5: Doctor check improvement — `computer/parachute/cli.py`
+
+**What**: Make the token check in `cmd_doctor` more actionable.
+
+Current (line 1744-1750): Returns `"no token found (run: parachute install)"`.
+
+Updated:
+```python
+def check_token():
+    token = _load_token(parachute_dir) or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
+    if token:
+        return True, f"{token[:12]}..."
+    return False, (
+        "no token found\n"
+        "      Fix: Run `claude setup-token` then `parachute config set token <value>`\n"
+        "      Or: Paste in Settings > Claude Authentication"
+    )
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `computer/parachute/cli.py` | Fix `_config_set` guard, improve doctor token check |
+| `computer/parachute/api/settings.py` | Add `GET/PUT /api/settings/token` endpoints |
+| `computer/parachute/lib/typed_errors.py` | Better `EXPIRED_TOKEN` message copy |
+| `app/lib/features/settings/widgets/claude_auth_section.dart` | Token paste flow + status |
+
+## What's NOT Changing
+
+- `claude_sdk.py` — already correctly passes `CLAUDE_CODE_OAUTH_TOKEN` to SDK env. No code change needed.
+- `orchestrator.py` — already reads token from settings at stream time (`get_settings().claude_code_oauth_token`). Hot-reload in Step 2 makes it pick up the new value.
+- `config.py` — `save_token()` and `_load_token()` already exist and work correctly.
+
+## Risks
+
+- **Hot-reload race**: If a stream is in-flight when the token is updated, that stream keeps the old token (captured at start). Acceptable — next stream gets the new token.
+- **Token validation**: We don't validate the token format on save. Could add a basic prefix check (`sk-ant-` or `oauth-`) but not blocking — bad tokens will fail at SDK call time with a clear typed error.
+
+## Test Plan
+
+- [ ] `parachute config set token test-value` → writes `.token`, prints masked confirmation
+- [ ] `curl localhost:3333/api/settings/token` → returns configured status
+- [ ] `curl -X PUT localhost:3333/api/settings/token -d '{"token":"..."}' -H 'Content-Type: application/json'` → saves and hot-reloads
+- [ ] App settings shows token status, paste flow works
+- [ ] With invalid token, chat attempt shows "Token Expired or Invalid" error card with Settings action
+- [ ] `parachute doctor` shows actionable fix when token is missing


### PR DESCRIPTION
## Summary

- **Unblock `parachute config set token`** — now saves to `~/.parachute/.token` instead of rejecting with an error
- **Add token API endpoints** — `GET/PUT /api/settings/token` with hot-reload so new sessions pick up the token immediately
- **Replace "Run claude login" with token paste flow** — app settings now shows token status and a dialog for pasting `claude setup-token` output
- **Improve error messages** — `EXPIRED_TOKEN` typed error now tells users exactly what to do; `parachute doctor` gives actionable fix instructions

Closes #349

## Testing

- Unit tests updated: `test_set_saves_token` replaces `test_set_rejects_token` (18/18 CLI tests pass)
- Flutter analyze passes with no issues on the rewritten `claude_auth_section.dart`
- Pre-existing test failure in `test_daily_module.py` (unrelated date filter issue)

## Test plan
- [ ] `parachute config set token <value>` writes `.token` and prints masked confirmation
- [ ] `curl localhost:3333/api/settings/token` returns configured status
- [ ] `curl -X PUT localhost:3333/api/settings/token -d '{"token":"..."}' -H 'Content-Type: application/json'` saves and hot-reloads
- [ ] App settings shows token status, paste dialog works
- [ ] With invalid token, chat shows "Token Expired or Invalid" error card
- [ ] `parachute doctor` shows actionable fix when token is missing

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)